### PR TITLE
Swap order of SSH arguments, putting ForwardAgent last

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [ssh_connection]
-ssh_args = "-o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=5m -o LogLevel=QUIET"
+ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ControlMaster=auto -o ControlPersist=5m -o LogLevel=QUIET -o ForwardAgent=yes"
 control_path = /tmp/ansible-%%r@%%h:%%p
 
 [defaults]


### PR DESCRIPTION
This fixes an apparent bug on an out-of-the-box Ubuntu 22.04 install.