### PR TITLE
Update Charts version and gnbsim image

### DIFF
--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -15,15 +15,17 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true	# set to false to place under control of ROC
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/4gc/roles/core/templates/radio-4g-values.yaml"
-  ran_subnet: ""	# empty string implies subnet comes from 'data_iface'
+  ran_subnet: ""	# set to empty string to get subnet from 'data_iface'
   helm:
     chart_ref: aether/sd-core
-    chart_version: 1.0.4
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
+    iface: "access"
+    mode: af_packet		# Options: af_packet or dpdk
   mme:
     ip: "10.76.28.113"
 

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -18,11 +18,11 @@ core:
   standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/radio-5g-values.yaml"
-  ran_subnet: ""		# empty string implies subnet comes from 'data_iface'
+  ran_subnet: ""	# set to empty string to get subnet from 'data_iface'
   helm:
-    local_charts: false
+    local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
-  ran_subnet: "172.20.0.0/16"
+  ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
-    local_charts: false
+    local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -33,7 +33,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.3
+      image: omecproject/5gc-gnbsim:rel-1.4.5
       prefix: gnbsim
       count: 2
     network:

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
-  ran_subnet: "172.20.0.0/16"
+  ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
-    local_charts: false
+    local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
   ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -33,7 +33,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.3
+      image: omecproject/5gc-gnbsim:rel-1.4.5
       prefix: gnbsim
       count: 1
     network:

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
-  ran_subnet: "172.20.0.0/16"
+  ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
-    local_charts: false
+    local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -30,7 +30,7 @@ core:
     helm:
       local_charts: false
       chart_ref: aether/bess-upf
-      chart_version: 1.0.2
+      chart_version: 1.0.5
     values_file: "deps/5gc/roles/upf/templates/upf-5g-values.yaml"
   amf:
     ip: "10.76.28.113"

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -15,18 +15,18 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-sriov-values.yaml"
   ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
-    mode: dpdk			# Options: af_packet or dpdk
+    mode: dpdk		# Options: af_packet or dpdk
     # If mode set to 'dpdk':
     #    - make sure at least two VF devices are created out of 'data_iface'
     #      and these devices are attached to vfio-pci driver;
@@ -37,7 +37,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.3
+      image: omecproject/5gc-gnbsim:rel-1.4.5
       prefix: gnbsim
       count: 1
     network:

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
-  ran_subnet: "172.20.0.0/16"
+  ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
-    local_charts: false
+    local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: false
+  standalone: false		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
   ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
-    local_charts: false
+    local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -46,11 +46,10 @@ core:
   amf:
     ip: "10.76.28.113"
 
-
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.3
+      image: omecproject/5gc-gnbsim:rel-1.4.5
       prefix: gnbsim
       count: 2
     network:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,14 +15,14 @@ k8s:
     version: v3.10.3
 
 core:
-  standalone: true
+  standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
   ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.12
+    chart_version: 1.0.18
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -33,7 +33,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.3
+      image: omecproject/5gc-gnbsim:rel-1.4.5
       prefix: gnbsim
       count: 1
     network:


### PR DESCRIPTION
This PR includes:
1. Update SD-Core Helm Charts version to `1.0.18`, which includes improvements in several CP images
2. Update `gnbsim` image tag to `rel-1.4.5`
3. Other minor comment edits such that the comments are aligned across all blueprints with the goal of showing only "true" changes in git status/diff after copying a blueprint into the `main.yml` blueprint

These changes were tested using `OnRamp` quickstart blueprint will all profiles enabled

NOTE: `main.yml` and `main-quickstart.yml` blueprints are identical. What about deleting `main-quickstart.yml` and use `main.yml` as default and for `quickstart` documentation/tests?