### PR TITLE
Improvements releated to UERANSIM

### DIFF
--- a/hosts.ini
+++ b/hosts.ini
@@ -12,5 +12,13 @@ node1
 #node3
 
 [gnbsim_nodes]
-node1
+#node1
+#node4
+
+[oai_nodes]
+#node2
+#node4
+
+[ueransim_nodes]
+#node2
 #node4

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -18,11 +18,11 @@ core:
   standalone: true		# set to false to place under control of ROC
   data_iface: ens18
   values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
-  ran_subnet: "172.20.0.0/16"	# set to empty string to get subnet from 'data_iface'
+  ran_subnet: ""	# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.0.14
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -35,6 +35,9 @@ ueransim:
     0:
       - "custom-gnb.yaml"
       - "custom-ue.yaml"
+    # 1:
+    #   - "custom-gnb-1.yaml"
+    #   - "custom-ue-1.yaml"
 
 amp:
   roc_models: "deps/amp/roles/roc-load/templates/roc-5g-models.json"


### PR DESCRIPTION
This PR addresses the following:
1. Adds the additional "groups" in the hosts.ini file for the other blueprints
2. Add IP address to `ueransim` configuration that is used in the `nr-gnb` for its `N3` interface