### PR TITLE
Use latest Helm CHarts and `gnbsim` image

### DIFF
--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -21,7 +21,7 @@ core:
   ran_subnet: ""	# set to empty string to get subnet from 'data_iface'
   helm:
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -33,7 +33,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.5
+      image: omecproject/5gc-gnbsim:rel-1.5.0
       prefix: gnbsim
       count: 2
     network:

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -33,7 +33,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.5
+      image: omecproject/5gc-gnbsim:rel-1.5.0
       prefix: gnbsim
       count: 1
     network:

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -30,7 +30,7 @@ core:
     helm:
       local_charts: false
       chart_ref: aether/bess-upf
-      chart_version: 1.0.5
+      chart_version: 1.1.0
     values_file: "deps/5gc/roles/upf/templates/upf-5g-values.yaml"
   amf:
     ip: "10.76.28.113"

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -37,7 +37,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.5
+      image: omecproject/5gc-gnbsim:rel-1.5.0
       prefix: gnbsim
       count: 1
     network:

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.14
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -30,7 +30,7 @@ core:
     helm:
       local_charts: false
       chart_ref: aether/bess-upf
-      chart_version: 1.0.5
+      chart_version: 1.1.0
     values_file: "deps/5gc/roles/upf/templates/upf-5g-values.yaml"
     additional_upfs:
       "1":
@@ -49,7 +49,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.5
+      image: omecproject/5gc-gnbsim:rel-1.5.0
       prefix: gnbsim
       count: 2
     network:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -22,7 +22,7 @@ core:
   helm:
     local_charts: false		# set chart_ref to local path name if true
     chart_ref: aether/sd-core
-    chart_version: 1.0.18
+    chart_version: 1.1.0
   upf:
     ip_prefix: "192.168.252.0/24"
     iface: "access"
@@ -33,7 +33,7 @@ core:
 gnbsim:
   docker:
     container:
-      image: omecproject/5gc-gnbsim:rel-1.4.5
+      image: omecproject/5gc-gnbsim:rel-1.5.0
       prefix: gnbsim
       count: 1
     network:


### PR DESCRIPTION
This PR includes the following:

1. Update Helm Charts version to use the latest SD-Core version for all blueprints
2. Update `gnbsim` image to use the latest version (which includes the new logger)
3. Tested changes with `quickstart` and `ueransim` blusprints

Below is the result for a test with `ueransim`
![image](https://github.com/user-attachments/assets/a14623e0-f09a-45f4-b999-44b68ecc9cb0)

**Note:** The `aether-ueransim-run` target did not work for me (it did not launch any of the `ueransim` processes)