### PR TITLE
Use GitHub Packages OCI registries

### DIFF
--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -17,7 +17,7 @@ core:
   values_file: "deps/4gc/roles/core/templates/radio-4g-values.yaml"
   ran_subnet: ""			# set to empty string to get subnet from 'data_iface'
   helm:
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -33,7 +33,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -43,7 +43,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: ""			# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -40,7 +40,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -50,7 +50,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -63,7 +63,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -73,7 +73,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-n3iwf.yml
+++ b/vars/main-n3iwf.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: ""		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -52,7 +52,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.36
 
   atomix:
@@ -62,7 +62,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -58,7 +58,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -68,7 +68,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -59,7 +59,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -69,7 +69,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -42,7 +42,7 @@ sdran:
 
     onosproject:
       helm:
-        chart_ref: onosproject/onos-operator
+        chart_ref: oci://ghcr.io/onosproject/onos-operator
         chart_version: 0.5.6
 
     store:

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -63,7 +63,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -73,7 +73,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: ""			# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -54,7 +54,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -64,7 +64,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: ""			# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -51,7 +51,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -61,7 +61,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -27,7 +27,7 @@ core:
     multihop_gnb: false			# set to true to override default N3 subnet
     helm:
       local_charts: false
-      chart_ref: aether/bess-upf
+      chart_ref: oci://ghcr.io/omec-project/bess-upf
       chart_version: 1.3.1
     values_file: "deps/5gc/roles/upf/templates/upf-5g-values.yaml"
     default_upf:
@@ -78,7 +78,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -88,7 +88,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,7 +18,7 @@ core:
   ran_subnet: "172.20.0.0/16"		# set to empty string to get subnet from 'data_iface'
   helm:
     local_charts: false			# set chart_ref to local path name if true
-    chart_ref: aether/sd-core
+    chart_ref: oci://ghcr.io/omec-project/sd-core
     chart_version: 3.1.3
   upf:
     access_subnet: "192.168.252.1/24"	# access subnet & gateway
@@ -59,7 +59,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: aether/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -69,7 +69,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/onos-operator
       chart_version: 0.5.6
 
   store:


### PR DESCRIPTION
Modify the chart_ref to point to GitHub Packages OCI registries for ONOS and OMEC Helm charts.