### PR TITLE
Update chart paths

### DIFF
--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -33,7 +33,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -43,7 +43,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -40,7 +40,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -50,7 +50,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -63,7 +63,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -73,7 +73,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-n3iwf.yml
+++ b/vars/main-n3iwf.yml
@@ -52,7 +52,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -62,7 +62,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -58,7 +58,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -68,7 +68,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -59,7 +59,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -69,7 +69,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -42,7 +42,7 @@ sdran:
 
     onosproject:
       helm:
-        chart_ref: oci://ghcr.io/onosproject/onos-operator
+        chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
         chart_version: 0.5.6
 
     store:

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -63,7 +63,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -73,7 +73,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -54,7 +54,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -64,7 +64,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -51,7 +51,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -61,7 +61,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -78,7 +78,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -88,7 +88,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -59,7 +59,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.37
 
   atomix:
@@ -69,7 +69,7 @@ amp:
 
   onosproject:
     helm:
-      chart_ref: oci://ghcr.io/onosproject/onos-operator
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
       chart_version: 0.5.6
 
   store:


### PR DESCRIPTION
Add charts/ to the path of onosproject Helm charts in GHCR to distinguish them from Docker images (which may have the same name).