### PR TITLE
Update ROC to use GHCR images

### DIFF
--- a/.github/workflows/quickstart-amp.yml
+++ b/.github/workflows/quickstart-amp.yml
@@ -93,7 +93,8 @@ jobs:
           make aether-5gc-install
           make aether-amp-install
           make aether-gnbsim-install
-          kubectl get pods -n aether-5gc
+          kubectl get pods -n aether-5gc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
+          kubectl get pods -n aether-roc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
           docker ps
 
       - name: Run gNBsim

--- a/.github/workflows/quickstart-oai.yml
+++ b/.github/workflows/quickstart-oai.yml
@@ -91,7 +91,7 @@ jobs:
           make k8s-install
           make 5gc-install
           make oai-gnb-install
-          kubectl get pods -n aether-5gc
+          kubectl get pods -n aether-5gc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
 
       - name: Run Emulated UE
         run: |

--- a/.github/workflows/quickstart-sdran.yml
+++ b/.github/workflows/quickstart-sdran.yml
@@ -91,8 +91,8 @@ jobs:
           make k8s-install
           make 5gc-install
           make sdran-install
-          kubectl get pods -n aether-5gc
-          kubectl get pods -n sdran
+          kubectl get pods -n aether-5gc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
+          kubectl get pods -n sdran -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
 
       - name: Validate Results
         continue-on-error: false

--- a/.github/workflows/quickstart-srsran.yml
+++ b/.github/workflows/quickstart-srsran.yml
@@ -99,7 +99,7 @@ jobs:
           make aether-5gc-install
           sleep 10
           make aether-srsran-gnb-install
-          kubectl get pods -n aether-5gc
+          kubectl get pods -n aether-5gc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
           docker ps
           sleep 10
 

--- a/.github/workflows/quickstart-ueransim.yml
+++ b/.github/workflows/quickstart-ueransim.yml
@@ -143,7 +143,7 @@ jobs:
           make aether-k8s-install
           make aether-5gc-install
           make aether-ueransim-install
-          kubectl get pods -n aether-5gc
+          kubectl get pods -n aether-5gc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
 
       - name: Run UERANSIM
         run: |

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -94,7 +94,7 @@ jobs:
           make aether-k8s-install
           make aether-5gc-install
           make aether-gnbsim-install
-          kubectl get pods -n aether-5gc
+          kubectl get pods -n aether-5gc -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,STATUS:.status.phase,RESTARTS:.status.containerStatuses[*].restartCount,IMAGE:.spec.containers[*].image
           docker ps
 
       - name: Run gNBsim

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
 	branch = main
 [submodule "deps/amp"]
 	path = deps/amp
-	url = https://github.com/opennetworkinglab/aether-amp.git
-	branch = main
+	url = https://github.com/andybavier/aether-amp.git
+	branch = use-ghcr
 [submodule "deps/4gc"]
 	path = deps/4gc
 	url = https://github.com/opennetworkinglab/aether-4gc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,8 @@
 	branch = main
 [submodule "deps/amp"]
 	path = deps/amp
-	url = https://github.com/andybavier/aether-amp.git
-	branch = use-ghcr
+	url = https://github.com/opennetworkinglab/aether-amp.git
+	branch = main
 [submodule "deps/4gc"]
 	path = deps/4gc
 	url = https://github.com/opennetworkinglab/aether-4gc.git

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -1,3 +1,7 @@
+global:
+  image:
+    registry: ghcr.io
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -63,8 +63,8 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
-      chart_version: 2.1.37
+      chart_ref: oci://ghcr.io/andybavier/charts/aether-roc-umbrella
+      chart_version: 2.1.40
 
   atomix:
     helm:

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -1,7 +1,3 @@
-global:
-  image:
-    registry: ghcr.io
-
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -59,7 +59,7 @@ amp:
   aether_roc:
     helm:
       local_charts: false
-      chart_ref: oci://ghcr.io/andybavier/charts/aether-roc-umbrella
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
       chart_version: 2.1.40
 
   atomix:


### PR DESCRIPTION
This PR updates the aether-roc-umbrella Helm chart to a version with GHCR images.  It also updates the GitHub workflows to show the image names, to make it easy to verify that GHCR images are used.

Tested with the Quickstart AMP workflow [here](https://github.com/andybavier/aether-onramp/actions/runs/22313032114/job/64602904571).

```
NAME                                       READY                 STATUS    RESTARTS   IMAGE
aether-mock-exporter-645f895786-78rp8      true                  Running   0          ghcr.io/onosproject/aether-mock-exporter:v0.4.2
onos-cli-67998f4b95-xcslh                  true                  Running   0          ghcr.io/onosproject/onos-cli:v0.9.39
onos-config-69f5979879-8v7s5               true,true,true,true   Running   0,0,0,0    ghcr.io/onosproject/onos-config:v1.1.6,ghcr.io/onosproject/aether-2.0.x:2.0.16-aether-2.0.x,ghcr.io/onosproject/aether-2.1.x:2.1.16-aether-2.1.x,atomix/sidecar:v1.1.3
onos-topo-b67d777c6-mvqcd                  true,true             Running   0,0        ghcr.io/onosproject/onos-topo:v1.0.4,atomix/sidecar:v1.1.3
roc-aether-roc-api-5694f677ff-5ppqm        true                  Running   0          ghcr.io/onosproject/aether-roc-api:v0.10.30
roc-aether-roc-gui-v2-1-74ddc8fd67-ggqb8   true                  Running   0          ghcr.io/onosproject/aether-roc-gui:v0.10.4
roc-consensus-0                            true                  Running   0          atomix/raft-node
roc-consensus-1                            true                  Running   0          atomix/raft-node
roc-consensus-2                            true                  Running   0          atomix/raft-node
roc-grafana-7dc445b9d8-2j7tz               true,true,true        Running   0,0,0      quay.io/kiwigrid/k8s-sidecar:1.21.0,quay.io/kiwigrid/k8s-sidecar:1.21.0,grafana/grafana:9.3.1
roc-sdcore-adapter-v2-1-dd9c8d7c7-s4c6n    true                  Running   0          ghcr.io/onosproject/sdcore-adapter:v0.4.9

2026-02-23T22:58:12.344Z	INFO	gnbsim/gnbsim.go:186	Ue's Passed: 5, Ue's Failed: 0	{"component": "GNBSIM", "category": "Summary"}
```