### PR TITLE
airgap: gate apt update_cache on operator-set airgapped.enabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,29 @@ deployed. By default, it is configured for the Quick Start deployment.
 The other files define other common configurations, any one of which
 you can copy to `main.yml`, and then edit to account for your local
 details. These alternative configurations are identified in the README.
+
+## Deploying Offline / On Local Mirrors (Airgap)
+
+Several roles run `apt: update_cache=yes` to refresh the apt cache
+before installing packages (`iptables-persistent` in the 5gc/router
+and oai/router roles, `python3-software-properties` in
+amp/monitor, the docker-ce stack in srsran/ocudu/oai/n3iwf/gnbsim/
+oscric docker roles, build deps in ueransim/simulator). On a host
+that can't reach upstream apt archives — airgapped sites, baked
+images, internal mirrors that don't need upstream refresh — that
+refresh hard-fails and aborts the install.
+
+Set the `airgapped` block in `vars/main.yml` (and in any
+`vars/main-<flavor>.yml` you `cp` over `main.yml`) to opt out:
+
+```yaml
+airgapped:
+  enabled: true                 # skip `apt update_cache` for offline / mirror-only sites
+```
+
+When `enabled: true`, every gated `apt: update_cache` call site is
+skipped. Operators are responsible for ensuring the required
+packages are already installed (offline bundle, baked image, or a
+local mirror keeping the apt cache fresh out-of-band) before running
+the install. The default (`enabled: false`) preserves online
+behaviour — apt cache is refreshed as before.

--- a/deps/4gc/vars/main.yml
+++ b/deps/4gc/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 core:
   standalone: true
   data_iface: ens18

--- a/deps/5gc/roles/router/tasks/install.yml
+++ b/deps/5gc/roles/router/tasks/install.yml
@@ -417,7 +417,7 @@
   apt:
     name: iptables-persistent
     state: present
-    update_cache: yes
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
   when: inventory_hostname in groups['master_nodes']
   become: true
   environment: "{{ proxy_env | combine({'DEBIAN_FRONTEND': 'noninteractive'}) }}"

--- a/deps/5gc/vars/main.yml
+++ b/deps/5gc/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 core:
   standalone: true
   data_iface: ens18

--- a/deps/amp/roles/monitor/tasks/install.yml
+++ b/deps/amp/roles/monitor/tasks/install.yml
@@ -4,7 +4,9 @@
 - name: update cache
   apt:
     update_cache: yes
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install software-properties-common package

--- a/deps/amp/vars/main.yml
+++ b/deps/amp/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 amp:
   roc_models: "roles/roc-load/templates/roc-5g-models.json"
   monitor_dashboard: "roles/monitor-load/templates/5g-monitoring"

--- a/deps/gnbsim/roles/docker/tasks/install.yml
+++ b/deps/gnbsim/roles/docker/tasks/install.yml
@@ -89,7 +89,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['gnbsim_nodes']
+  when:
+    - inventory_hostname in groups['gnbsim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Delete previous apt sources (1)
@@ -186,7 +188,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['gnbsim_nodes']
+  when:
+    - inventory_hostname in groups['gnbsim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install Docker packages

--- a/deps/gnbsim/roles/router/tasks/install.yml
+++ b/deps/gnbsim/roles/router/tasks/install.yml
@@ -287,7 +287,7 @@
   apt:
     name: iptables-persistent
     state: present
-    update_cache: yes
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
   environment: "{{ proxy_env | combine({'DEBIAN_FRONTEND': 'noninteractive'}) }}"

--- a/deps/gnbsim/vars/main.yml
+++ b/deps/gnbsim/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 gnbsim:
   docker:
     container:

--- a/deps/k8s/vars/main.yml
+++ b/deps/k8s/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/deps/n3iwf/roles/docker/tasks/install.yml
+++ b/deps/n3iwf/roles/docker/tasks/install.yml
@@ -89,7 +89,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['n3iwf_nodes']
+  when:
+    - inventory_hostname in groups['n3iwf_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Delete previous apt sources (1)
@@ -186,7 +188,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['n3iwf_nodes']
+  when:
+    - inventory_hostname in groups['n3iwf_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install Docker packages

--- a/deps/n3iwf/vars/main.yml
+++ b/deps/n3iwf/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 n3iwf:
   docker:
     image: ghcr.io/omec-project/5gc-n3iwf:rel-1.1.0

--- a/deps/oai/roles/docker/tasks/install.yml
+++ b/deps/oai/roles/docker/tasks/install.yml
@@ -89,7 +89,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['oai_nodes']
+  when:
+    - inventory_hostname in groups['oai_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Delete previous apt sources (1)
@@ -186,7 +188,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['oai_nodes']
+  when:
+    - inventory_hostname in groups['oai_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install Docker packages

--- a/deps/oai/roles/router/tasks/install.yml
+++ b/deps/oai/roles/router/tasks/install.yml
@@ -57,7 +57,7 @@
   apt:
     name: iptables-persistent
     state: present
-    update_cache: yes
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
   when: inventory_hostname in groups['oai_nodes'] and oai.docker.network.name != "host"
   become: true
   environment: "{{ proxy_env | combine({'DEBIAN_FRONTEND': 'noninteractive'}) }}"

--- a/deps/oai/vars/main.yml
+++ b/deps/oai/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 oai:
   docker:
     container:

--- a/deps/ocudu/roles/docker/tasks/install.yml
+++ b/deps/ocudu/roles/docker/tasks/install.yml
@@ -89,7 +89,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['ocudu_nodes']
+  when:
+    - inventory_hostname in groups['ocudu_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Delete previous apt sources (1)
@@ -186,7 +188,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['ocudu_nodes']
+  when:
+    - inventory_hostname in groups['ocudu_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install Docker packages

--- a/deps/ocudu/vars/main.yml
+++ b/deps/ocudu/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 ocudu:
   docker:
     container:

--- a/deps/oscric/roles/docker/tasks/install.yml
+++ b/deps/oscric/roles/docker/tasks/install.yml
@@ -89,7 +89,9 @@
 - name: update apt cache before removing old sources
   apt:
     update_cache: true
-  when: inventory_hostname in groups['oscric_nodes']
+  when:
+    - inventory_hostname in groups['oscric_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Delete previous apt sources (1)
@@ -186,7 +188,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['oscric_nodes']
+  when:
+    - inventory_hostname in groups['oscric_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install Docker packages

--- a/deps/oscric/vars/main.yml
+++ b/deps/oscric/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 oscric:
   e2t:
     ip: "127.0.0.1"

--- a/deps/srsran/roles/docker/tasks/install.yml
+++ b/deps/srsran/roles/docker/tasks/install.yml
@@ -89,7 +89,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['srsran_nodes']
+  when:
+    - inventory_hostname in groups['srsran_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Delete previous apt sources (1)
@@ -186,7 +188,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['srsran_nodes']
+  when:
+    - inventory_hostname in groups['srsran_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: install Docker packages

--- a/deps/srsran/vars/main.yml
+++ b/deps/srsran/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 srsran:
   docker:
     container:

--- a/deps/ueransim/roles/simulator/tasks/install.yml
+++ b/deps/ueransim/roles/simulator/tasks/install.yml
@@ -15,7 +15,9 @@
 - name: update apt cache
   apt:
     update_cache: true
-  when: inventory_hostname in groups['ueransim_nodes']
+  when:
+    - inventory_hostname in groups['ueransim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Install dependencies

--- a/deps/ueransim/vars/main.yml
+++ b/deps/ueransim/vars/main.yml
@@ -1,3 +1,8 @@
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 core:
   upf:
     access_subnet: "192.168.252.1/24"

--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-n3iwf.yml
+++ b/vars/main-n3iwf.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-ocudu.yml
+++ b/vars/main-ocudu.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -4,6 +4,11 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
+# for full documentation.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,6 +4,18 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
+# Airgap behaviour for `apt: update_cache` tasks.
+#
+# When `enabled: true`, roles that touch apt (5gc/router, the docker
+# installs under srsran/ocudu/oai/n3iwf/gnbsim/oscric, ueransim/simulator,
+# amp/monitor, gnbsim/router, oai/router) skip `update_cache`. Set this
+# for offline / airgapped sites or for sites running off a local mirror
+# that does not need refresh from upstream. See the airgap section in
+# the README and the Aether Docs (https://docs.aetherproject.org/) for
+# operational details.
+airgapped:
+  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+
 k8s:
   rke2:
     version: v1.24.17+rke2r1


### PR DESCRIPTION
Closes #174.

## Problem

Roles that touch apt (`5gc/router`, the docker installs under
`srsran/ocudu/oai/n3iwf/gnbsim/oscric`, `ueransim/simulator`,
`amp/monitor`, `gnbsim/router`, `oai/router`) call
`apt: update_cache=yes`, which hard-fails on any host that can't reach
upstream apt archives. Operators running offline sites — airgap, baked
images, or local mirrors that don't need a refresh from upstream —
currently have no way to opt out short of patching the role tasks.

## Change

Add an explicit operator switch:

```yaml
airgapped:
  enabled: false                 # set true to skip `apt update_cache`
```

Every `update_cache` call site in the affected roles is gated on
`not (airgapped.enabled | default(false) | bool)`. With the default
(`false`), behaviour is identical to today's online installs. Setting
`airgapped.enabled: true` in `vars/main.yml` (or any inventory-level
override) skips the cache refresh on every gated call site.

The block is propagated to every operator-facing vars file:

- `vars/main.yml` (the canonical default)
- All twelve `vars/main-*.yml` flavor variants — operators picking a
  flavor via `cp vars/main-<flavor>.yml vars/main.yml` get the same
  default
- Every per-dep `deps/*/vars/main.yml` — so per-dep playbook
  invocations also see the var

## Shape choice

An earlier revision of this PR did connectivity auto-detection via a
`uri` HEAD probe against `archive.ubuntu.com`. Dropped per @gab-arrobo's
review feedback ([#180 (comment)](https://github.com/opennetworkinglab/aether-onramp/pull/180/files#r3089152513)):

- Operators know up front whether their deployment has internet egress;
  an explicit switch is more honest about that workflow.
- A flaky upstream connection could make the probe succeed once and fail
  another time — non-deterministic behaviour worse than the current
  hard-fail.
- ~30 lines of probe block per role, deleted.

## Behaviour summary

| Scenario                                                | Before                                         | After                                                  |
|---------------------------------------------------------|------------------------------------------------|--------------------------------------------------------|
| Default install on a host with upstream egress          | apt update succeeds                            | unchanged                                              |
| Default install on an airgapped host                    | task hard-fails on apt update                  | unchanged (operator must set `airgapped.enabled: true`)|
| Airgap install with `airgapped.enabled: true`           | required patching the role task                | apt update is skipped, package install proceeds       |
| Operator copies `vars/main-<flavor>.yml` over `main.yml`| flavor variant lacked any airgap knob          | flavor carries the same `airgapped:` block            |

## Follow-up work

- Documentation update against [aether-docs](https://github.com/opennetworkinglab/aether-docs)
  to describe the airgap/local-mirror operator workflow and the
  `airgapped.enabled` knob.
- The `python3-kubernetes` prereq added in #178/#183 also calls
  `apt: update_cache` — that PR should adopt the same `airgapped.enabled`
  gate when it lands, so airgap installs don't regress through it.