### PR TITLE
5gc core: fail loudly when rescue has nothing to recover

### DIFF
--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -208,6 +208,14 @@
       when: inventory_hostname in groups['master_nodes']
 
   rescue:
+    # Intentionally non-fatal: when helm failed because the cluster is
+    # unreachable or kubeconfig is missing, k8s_info will hit the same
+    # error. Letting it abort the rescue would mean the loud-fail task
+    # below never runs and operators see the k8s_info error instead of
+    # the underlying helm failure. failed_when: false registers
+    # pod_status in both the "empty namespace" and "API unreachable"
+    # cases; `pod_status.resources | default([])` below normalises
+    # both to an empty list so the loud-fail fires.
     - name: Get Pods Status
       kubernetes.core.k8s_info:
         api_version: v1
@@ -215,7 +223,35 @@
         namespace: aether-5gc
       register: pod_status
       changed_when: false
+      failed_when: false
       when: inventory_hostname in groups['master_nodes']
+
+    # The restart loop below can only recover from "pods were created but
+    # some are not Running". When pod_status.resources is empty the helm
+    # deploy never produced any pods (typical when chart_ref is
+    # unreachable, the cluster API is down, or kubeconfig is missing),
+    # so there is nothing for the rescue to fix. Re-raise with the
+    # original failure details so operators see the helm error directly
+    # instead of hunting through earlier task output.
+    # `pod_status.resources | length == 0` is true in two cases now
+    # that k8s_info is non-fatal: the namespace genuinely has no
+    # pods, OR k8s_info itself failed (cluster unreachable,
+    # kubeconfig missing, RBAC denial). Both indicate "nothing to
+    # recover" from this rescue's perspective; the surfaced
+    # ansible_failed_result tells the operator which one.
+    - name: fail loudly when helm deploy produced no pods to recover
+      ansible.builtin.fail:
+        msg: |-
+          sd-core helm deploy failed and no pods were found in
+          aether-5gc (the namespace is empty, or k8s_info could not
+          query the cluster API) — nothing for the rescue to recover.
+
+          Original failure in task '{{ ansible_failed_task.name | default('unknown', true) }}':
+          {{ ansible_failed_result.msg | default('', true)
+             | default(ansible_failed_result | default({}, true) | to_nice_yaml, true) }}
+      when:
+        - inventory_hostname in groups['master_nodes']
+        - (pod_status.resources | default([])) | length == 0
 
     - name: restart Pods if not running
       kubernetes.core.k8s:


### PR DESCRIPTION
Closes #175.

## Problem

The `block/rescue` around the sd-core helm deploy in `deps/5gc/roles/core/tasks/install.yml` was silently swallowing helm-fetch failures:

1. `kubernetes.core.helm` errors out (chart_ref unreachable, cluster API down, kubeconfig missing, etc.) before any resources are created.
2. The rescue runs `k8s_info` on the `aether-5gc` namespace — which may not even exist yet — returning an empty `resources` list, not an error.
3. The subsequent `restart Pods if not running` loop iterates over that empty list — no-op.
4. `always: pause 60`.

All three rescue tasks succeed, so ansible considers the block handled, the playbook exits 0, and any caller (controllers, CI, operators) sees "deploy succeeded" despite nothing having been installed.

Reproduced end-to-end during airgap integration: the ansible task recorded `status=succeeded`, but 15 minutes of `kubectl get pods -A` polling showed only `kube-system` workloads.

## Change

Insert a `fail:` task at the top of the rescue that re-raises when `pod_status.resources` is empty. The existing restart loop is preserved for the genuine "pods were created but some are not Running" case.

## Behaviour summary

| Scenario                                   | Before | After |
|--------------------------------------------|--------|-------|
| helm deploy succeeds                       | pass   | pass  |
| helm deploy fails, pods partially created, some not Running | rescue restarts stuck pods (pass) | rescue restarts stuck pods (pass) |
| helm deploy fails, no pods created at all  | silent pass (bug) | fail with original helm error visible |

## Testing

- Online deploy: unaffected, behaviour identical to current main.
- Airgap deploy with unreachable `chart_ref`: playbook now fails loudly at the rescue boundary with a message pointing at the preceding helm error, instead of silently succeeding.

## Notes

Alternative considered: drop the rescue entirely. The current pod-restart recovery is narrow enough that removing it may also be acceptable, but this change preserves it — the minimal diff to stop masking real failures.