### PR TITLE
5gc: auto-derive core.data_iface and drop unusable defaults

### DIFF
--- a/deps/5gc/roles/core/defaults/main.yml
+++ b/deps/5gc/roles/core/defaults/main.yml
@@ -1,6 +1,7 @@
 core:
   standalone: true
-  data_iface: data
+  # Empty = auto-derive from default-route interface at install time.
+  data_iface: ""
   values_file: "roles/core/templates/sdcore-5g-values.yaml"
   ran_subnet: "" # set it to empty to get subnet from 'data_iface'
 

--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -1,5 +1,32 @@
 ---
 
+# Resolve `core.data_iface` from the default-route interface when it
+# is unset or left at one of the stock defaults. See the router
+# role's install.yml for the full rationale.
+- name: derive core.data_iface from default-route interface when unset
+  ansible.builtin.set_fact:
+    core: "{{ core | combine({'data_iface': ansible_default_ipv4.interface}) }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - ansible_default_ipv4.interface is defined
+    - core.data_iface is not defined or core.data_iface in ['', 'data']
+
+- name: validate core.data_iface is set and exists on this host
+  ansible.builtin.fail:
+    msg: >-
+      core.data_iface (={{ core.data_iface | default('<unset>') | to_json }}) is
+      not a valid network interface on this host. Either it was left
+      at a placeholder and no IPv4 default route was available to
+      derive from, or the configured value does not match any
+      interface in ansible_interfaces ({{ ansible_interfaces | join(', ') }}).
+      Set core.data_iface in vars/main.yml to the data-plane
+      interface name on the target node.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - (core.data_iface is not defined)
+      or (core.data_iface in ['', 'data'])
+      or (core.data_iface not in (ansible_interfaces | default([])))
+
 - name: check configured VF resources for built-in UPF
   block:
     - name: Get number of configured VFs for interface {{ core.data_iface }}

--- a/deps/5gc/roles/router/defaults/main.yml
+++ b/deps/5gc/roles/router/defaults/main.yml
@@ -1,2 +1,3 @@
 core:
-  data_iface: data
+  # Empty = auto-derive from default-route interface at install time.
+  data_iface: ""

--- a/deps/5gc/roles/router/tasks/install.yml
+++ b/deps/5gc/roles/router/tasks/install.yml
@@ -2,6 +2,38 @@
 
 # TODO: running on master node for now (fix to run on multiple nodes)
 
+# Resolve `core.data_iface` from the default-route interface when it
+# is unset, empty, or left at the legacy placeholder `data`. Empty
+# string is the new shipped default in vars/main.yml and the role
+# defaults; `data` is kept in the trigger set for backward
+# compatibility with older checkouts. `ens18` is NOT treated as a
+# placeholder — on proxmox/QEMU guests it is a legitimate interface
+# name, so an explicit `core.data_iface: ens18` must be honoured.
+# Any other explicit operator value is preserved as-is.
+- name: derive core.data_iface from default-route interface when unset
+  ansible.builtin.set_fact:
+    core: "{{ core | combine({'data_iface': ansible_default_ipv4.interface}) }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - ansible_default_ipv4.interface is defined
+    - core.data_iface is not defined or core.data_iface in ['', 'data']
+
+- name: validate core.data_iface is set and exists on this host
+  ansible.builtin.fail:
+    msg: >-
+      core.data_iface (={{ core.data_iface | default('<unset>') | to_json }}) is
+      not a valid network interface on this host. Either it was left
+      at a placeholder and no IPv4 default route was available to
+      derive from, or the configured value does not match any
+      interface in ansible_interfaces ({{ ansible_interfaces | join(', ') }}).
+      Set core.data_iface in vars/main.yml to the data-plane
+      interface name on the target node.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - (core.data_iface is not defined)
+      or (core.data_iface in ['', 'data'])
+      or (core.data_iface not in (ansible_interfaces | default([])))
+
 - set_fact:
     systemd_network_dir: /etc/systemd/network
     systemd_system_dir: /etc/systemd/system

--- a/deps/5gc/roles/router/tasks/uninstall.yml
+++ b/deps/5gc/roles/router/tasks/uninstall.yml
@@ -2,10 +2,80 @@
 
 # TODO: running on master node for now (fix to run on multiple nodes)
 
+# Path is shared with install.yml; declared up-front so the recovery
+# slurp below and the later set_fact block use one source of truth.
+- name: declare paths shared with install.yml
+  ansible.builtin.set_fact:
+    router_sysctl_backup_file: /var/lib/aether-5gc-router-sysctl-backup.conf
+
+# Recover the install-time data_iface from the sysctl backup file.
+# The backup was written by install.yml in the form
+#     net/ipv4/conf/<install-time-iface>/forwarding=<original-value>
+# Reading it back here guarantees uninstall targets the same
+# interface install used, even if the host's default route has since
+# moved to a different NIC. Operator overrides via vars/main.yml or
+# inventory still win; the auto-derive below only fires if both the
+# explicit override and the backup file are absent/unparseable.
+# `become: true`: the backup file is written by install at mode 0600
+# owned by root, so an unprivileged ansible_user can't slurp it.
+- name: read sysctl backup file for install-time data_iface
+  ansible.builtin.slurp:
+    src: "{{ router_sysctl_backup_file }}"
+  register: _router_sysctl_backup
+  failed_when: false
+  changed_when: false
+  become: true
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - core.data_iface is not defined or core.data_iface in ['', 'data']
+
+- name: recover core.data_iface from sysctl backup file
+  ansible.builtin.set_fact:
+    core: "{{ core | combine({'data_iface':
+      _router_sysctl_backup.content | b64decode
+        | regex_findall('(?m)^net/ipv4/conf/([^/]+)/forwarding=') | first }) }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - core.data_iface is not defined or core.data_iface in ['', 'data']
+    - _router_sysctl_backup.content is defined
+    - (_router_sysctl_backup.content | b64decode) is regex('(?m)^net/ipv4/conf/[^/]+/forwarding=')
+
+# Mirror the install-time auto-derive when neither an explicit
+# operator value nor the backup-file recovery resolved the interface.
+- name: derive core.data_iface from default-route interface when unset
+  ansible.builtin.set_fact:
+    core: "{{ core | combine({'data_iface': ansible_default_ipv4.interface}) }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - ansible_default_ipv4.interface is defined
+    - core.data_iface is not defined or core.data_iface in ['', 'data']
+
+# Non-fatal in uninstall: cleanup is best-effort (most tasks below
+# use `ignore_errors: yes`), so a hard failure here would block
+# legitimate uninstall runs on hosts where the install-time interface
+# is no longer present (renamed NIC, decommissioned hardware, etc.).
+# Surface a warning instead — interface-dependent tasks downstream
+# will fail individually under their existing ignore_errors and the
+# rest of the cleanup still completes.
+- name: warn when core.data_iface cannot be resolved on this host
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: core.data_iface (={{ core.data_iface | default('<unset>') | to_json }})
+      is not a valid network interface on this host. Either it was
+      left at a placeholder and no IPv4 default route was available
+      to derive from, or the configured value does not match any
+      interface in ansible_interfaces ({{ ansible_interfaces | join(', ') }}).
+      Interface-specific cleanup steps may be skipped; re-run with
+      `core.data_iface` set explicitly to fully clean up.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - (core.data_iface is not defined)
+      or (core.data_iface in ['', 'data'])
+      or (core.data_iface not in (ansible_interfaces | default([])))
+
 - set_fact:
     systemd_network_dir: /etc/systemd/network
     systemd_system_dir: /etc/systemd/system
-    router_sysctl_backup_file: /var/lib/aether-5gc-router-sysctl-backup.conf
     router_data_iface_forwarding_sysctl: net/ipv4/conf/{{ core.data_iface }}/forwarding
     router_data_iface_forwarding_backup_regexp: >-
       ^(net\.ipv4\.conf\.{{ core.data_iface | regex_escape }}\.forwarding|net/ipv4/conf/{{ core.data_iface | regex_escape }}/forwarding)=(.+)$

--- a/deps/5gc/roles/upf/defaults/main.yml
+++ b/deps/5gc/roles/upf/defaults/main.yml
@@ -1,5 +1,6 @@
 core:
-  data_iface: ens18
+  # Empty = auto-derive from default-route interface at install time.
+  data_iface: ""
   ran_subnet: "172.20.0.0/16"  # set to empty string to get subnet from 'data_iface'
 
   upf:

--- a/deps/5gc/roles/upf/tasks/install.yml
+++ b/deps/5gc/roles/upf/tasks/install.yml
@@ -1,5 +1,32 @@
 ---
 
+# Resolve `core.data_iface` from the default-route interface when it
+# is unset or left at one of the stock defaults. See the router
+# role's install.yml for the full rationale.
+- name: derive core.data_iface from default-route interface when unset
+  ansible.builtin.set_fact:
+    core: "{{ core | combine({'data_iface': ansible_default_ipv4.interface}) }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - ansible_default_ipv4.interface is defined
+    - core.data_iface is not defined or core.data_iface in ['', 'data']
+
+- name: validate core.data_iface is set and exists on this host
+  ansible.builtin.fail:
+    msg: >-
+      core.data_iface (={{ core.data_iface | default('<unset>') | to_json }}) is
+      not a valid network interface on this host. Either it was left
+      at a placeholder and no IPv4 default route was available to
+      derive from, or the configured value does not match any
+      interface in ansible_interfaces ({{ ansible_interfaces | join(', ') }}).
+      Set core.data_iface in vars/main.yml to the data-plane
+      interface name on the target node.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - (core.data_iface is not defined)
+      or (core.data_iface in ['', 'data'])
+      or (core.data_iface not in (ansible_interfaces | default([])))
+
 - name: check configured VF resources for additional UPFs
   block:
     - name: Get number of configured VFs for interface {{ core.data_iface }}

--- a/deps/5gc/vars/main.yml
+++ b/deps/5gc/vars/main.yml
@@ -5,7 +5,12 @@ airgapped:
 
 core:
   standalone: true
-  data_iface: ens18
+  # Name of the data-plane interface on the managed node (e.g. eth0,
+  # enp5s0). Leave empty to auto-derive from the default-route
+  # interface. Any explicit value is honoured as-is. The legacy
+  # role-default placeholder "data" is also treated as unset for
+  # backward compatibility.
+  data_iface: ""
   values_file: "roles/core/templates/sdcore-5g-values.yaml"
   ran_subnet: "172.20.0.0/16"     # set it to empty to get subnet from 'data_iface'
 


### PR DESCRIPTION
Closes #177.

## Problem

`core.data_iface` ships as:

- `ens18` in `deps/5gc/vars/main.yml`
- `ens18` in `deps/5gc/roles/upf/defaults/main.yml`
- `data` in `deps/5gc/roles/{router,core}/defaults/main.yml`

Neither default is good out of the box:

- Modern Ubuntu/systemd names interfaces from PCI slots (`enp5s0`, `ens3`, …), so the `ens18` default fails immediately on most hosts with `cannot stat /proc/sys/net/ipv4/conf/ens18/forwarding`.
- On proxmox/QEMU guests, `ens18` *is* a real interface — accepting the default silently points the role at the wrong NIC instead of failing, which is worse than the first case.
- `data` is never a real interface name; the `data` defaults in the per-role `defaults/main.yml` files are placeholders the stock vars always override.

## Change

- Ship `core.data_iface: ""` everywhere (vars + all four role defaults, including upf).
- At the top of each `tasks/install.yml` (and `tasks/uninstall.yml` for the router role), resolve `core.data_iface` from `ansible_default_ipv4.interface` when it is unset, empty, or left at the legacy `data` placeholder. Scoped to `groups['master_nodes']`.
- Follow with a validation `fail:` that catches both the "still unset after derive" case and an operator typo (an explicit `data_iface` value that doesn't match any entry in `ansible_interfaces`), pointing at `vars/main.yml` with the list of interfaces actually present on the host.

`ens18` is deliberately **not** in the auto-derive trigger set: on the hosts where that name is legitimately the data-plane interface, an operator's explicit `core.data_iface: ens18` should be honoured as-is. Only the two values that are never valid interface names (`""` and `data`) are replaced.

## Behaviour summary

| Scenario                                              | Before                                    | After                                       |
|-------------------------------------------------------|-------------------------------------------|---------------------------------------------|
| Operator sets `core.data_iface: eth0` (or any real NIC) | honoured                                  | honoured (unchanged)                        |
| Operator accepts shipped default on a host where default-route interface exists | sysctl failure or silent wrong-NIC | auto-derived to the default-route interface |
| Operator accepts shipped default on a host with no default route | confusing sysctl error at runtime | explicit `fail:` pointing at vars/main.yml  |
| Operator explicitly sets `core.data_iface: ens18` on proxmox | honoured                                  | honoured (unchanged)                        |
| Operator sets `core.data_iface: eth3` but only eth0 exists | confusing sysctl error at runtime | explicit `fail:` listing actual interfaces  |

## Testing

Online deploy with `core.data_iface` set explicitly: no behaviour change.

Deploy with the default: on an LXD VM with `enp5s0`, the derive task picks it up and the role proceeds. Regression-tested against an aether-ops-bootstrap integration flow where this was the first symptom operators hit.

## Notes

Derive + validate tasks are duplicated across four files (router install, router uninstall, core install, upf install) rather than factored into a shared task file, to match the existing self-contained-per-role pattern in this repo. A shared-prelude refactor across this PR, the airgap probe (#174), and the python3-kubernetes prereq (#178) would be a sensible follow-up once several common preludes exist.