### PR TITLE
ansible: install python3-kubernetes up-front in roles using kubernetes.core

### DIFF
--- a/deps/4gc/roles/core/tasks/install.yml
+++ b/deps/4gc/roles/core/tasks/install.yml
@@ -1,5 +1,19 @@
 ---
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: find {{ core.data_iface }}'s subnet for RAN
   command:
     argv:

--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -27,6 +27,21 @@
       or (core.data_iface in ['', 'data'])
       or (core.data_iface not in (ansible_interfaces | default([])))
 
+# kubernetes.core modules (helm, k8s, k8s_info, etc.) require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front so later tasks in
+# this role don't fail with "Failed to import the required Python
+# library (kubernetes)". `airgapped.enabled` gates update_cache so
+# airgapped hosts don't try to reach unreachable archives; when unset,
+# the default of false preserves current online behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: check configured VF resources for built-in UPF
   block:
     - name: Get number of configured VFs for interface {{ core.data_iface }}

--- a/deps/5gc/roles/upf/tasks/install.yml
+++ b/deps/5gc/roles/upf/tasks/install.yml
@@ -27,6 +27,20 @@
       or (core.data_iface in ['', 'data'])
       or (core.data_iface not in (ansible_interfaces | default([])))
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: check configured VF resources for additional UPFs
   block:
     - name: Get number of configured VFs for interface {{ core.data_iface }}

--- a/deps/amp/roles/monitor-load/tasks/install.yml
+++ b/deps/amp/roles/monitor-load/tasks/install.yml
@@ -1,5 +1,19 @@
 ---
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: Create a k8s "aether-5gc" namespace
   kubernetes.core.k8s:
     name: aether-5gc

--- a/deps/amp/roles/monitor/tasks/install.yml
+++ b/deps/amp/roles/monitor/tasks/install.yml
@@ -1,5 +1,19 @@
 ---
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 #TODO: add in core code
 - name: update cache
   apt:

--- a/deps/amp/roles/roc/tasks/install.yml
+++ b/deps/amp/roles/roc/tasks/install.yml
@@ -1,5 +1,19 @@
 ---
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: add atomix chart repo
   kubernetes.core.helm_repository:
     name: atomix

--- a/deps/sdran/roles/platform/tasks/install.yaml
+++ b/deps/sdran/roles/platform/tasks/install.yaml
@@ -1,5 +1,19 @@
 ---
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: add atomix chart repo
   kubernetes.core.helm_repository:
     name: atomix

--- a/deps/sdran/roles/sdran/tasks/install.yaml
+++ b/deps/sdran/roles/sdran/tasks/install.yaml
@@ -1,5 +1,19 @@
 ---
 
+# kubernetes.core modules used later in this role require the python
+# `kubernetes` client library, which is NOT pulled in by a stock apt
+# install of ansible on Ubuntu. Install it up-front. `airgapped.enabled`
+# gates update_cache so airgapped hosts don't try to reach unreachable
+# archives; when unset, the default of false preserves current online
+# behaviour.
+- name: install kubernetes.core python prerequisite (python3-kubernetes)
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+    update_cache: "{{ not (airgapped.enabled | default(false) | bool) }}"
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: remove /tmp/sdran-values.yaml
   file:
     path: "/tmp/sdran-values.yaml"


### PR DESCRIPTION
Closes #178.

## Problem

The `kubernetes.core` collection's modules (`helm`, `k8s`, `k8s_info`, `helm_repository`, etc.) require the python `kubernetes` client library, which is **not** pulled in as a transitive dependency when ansible is installed from apt on Ubuntu. On a fresh host the first task to call any `kubernetes.core` module fails with:

```
Failed to import the required Python library (kubernetes) on <host>'s Python /usr/bin/python3.
Please read the module documentation and install it in the appropriate location.
```

This is undocumented and, when it surfaces inside a `block/rescue` (see #175), can look like a spurious success.

## Change

Install `python3-kubernetes` up-front in every role that uses the `kubernetes.core` collection, so later tasks in the same role find it already present.

- Each prereq task is guarded on `inventory_hostname in groups['master_nodes']` because every `kubernetes.core` call site in these roles is also master-only.
- `update_cache` gates on `not (airgapped | default(false) | bool)` — the same pattern proposed in the companion airgap PR (#174). Online installs refresh the cache as today; airgapped installs that set `airgapped: true` skip the refresh. With the var unset the expression defaults to the current online behaviour, so this PR stands alone without requiring #174 to merge first.

## Affected roles

| Role                               | Uses kubernetes.core via |
|------------------------------------|--------------------------|
| `deps/4gc/roles/core`              | helm, k8s, k8s_info      |
| `deps/5gc/roles/core`              | helm, k8s, k8s_info      |
| `deps/5gc/roles/upf`               | helm                     |
| `deps/amp/roles/monitor-load`      | k8s                      |
| `deps/amp/roles/monitor`           | helm_repository, helm    |
| `deps/amp/roles/roc`               | helm_repository, helm    |
| `deps/sdran/roles/platform`        | helm_repository, helm    |
| `deps/sdran/roles/sdran`           | helm                     |

## Alternative considered

A shared `roles/common/prereqs` role would avoid the duplicated block across 8 files. Kept out of this PR to minimise the diff and to match the "add to each role that uses the collection" shape the issue proposed. Happy to refactor to a common role in a follow-up if that's preferred.

## Testing

- Fresh Ubuntu 24.04 host without `python3-kubernetes`: before this change, first `kubernetes.core.k8s_info` call fails; after, the prereq task installs the package and the role proceeds.
- Host that already has `python3-kubernetes` installed: task reports `ok` (no change), subsequent behaviour identical to today.