### PR TITLE
5gc: populate ansible-user kubeconfig when k8s role is skipped

### DIFF
--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -42,6 +42,100 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
+# Ensure ~/.kube/config exists for the ansible user so kubernetes.core
+# tasks below find a valid config. The k8s role populates this on its
+# own install path (see deps/k8s/roles/rke2/tasks/install.yml) — and
+# also rewrites the server URL from 127.0.0.1 to the master's
+# ansible_host, which matters on multi-node. We must not clobber that
+# post-processing.
+#
+# Strategy: only act when ~/.kube/config is missing. When the k8s
+# role has already run (full onramp flow) the file exists and the
+# whole block is a no-op. When operators bring a pre-existing
+# cluster and skip the k8s role, the file is absent and we probe
+# /etc/rancher/{rke2,k3s}/*.yaml for a source to copy from.
+#
+# Operators can set `kubeconfig_source` in inventory vars to skip the
+# probe; to force-reinstall, delete ~/.kube/config first.
+- name: check for existing ansible-user kubeconfig
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.kube/config"
+  register: _user_kubeconfig_stat
+  when: inventory_hostname in groups['master_nodes']
+
+- name: locate on-disk cluster kubeconfig
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - /etc/rancher/rke2/rke2.yaml
+    - /etc/rancher/k3s/k3s.yaml
+  register: _kubeconfig_candidates
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is not defined
+
+- name: resolve kubeconfig_source to first existing candidate
+  ansible.builtin.set_fact:
+    kubeconfig_source: "{{ item.item }}"
+  loop: "{{ _kubeconfig_candidates.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('') }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is not defined
+    - item.stat.exists | default(false)
+
+- name: ensure ~/.kube exists for ansible user
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.kube"
+    state: directory
+    mode: "0700"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+
+- name: install cluster kubeconfig at ~/.kube/config
+  ansible.builtin.copy:
+    src: "{{ kubeconfig_source }}"
+    dest: "{{ ansible_env.HOME }}/.kube/config"
+    remote_src: yes
+    mode: "0600"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+  become: true
+
+- name: rewrite 127.0.0.1 in kubeconfig when master is remote
+  ansible.builtin.replace:
+    path: "{{ ansible_env.HOME }}/.kube/config"
+    regexp: 'https://127\.0\.0\.1:6443'
+    replace: "https://{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}:6443"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+    - hostvars[groups['master_nodes'][0]]['ansible_host'] is defined
+    - hostvars[groups['master_nodes'][0]]['ansible_host'] != '127.0.0.1'
+  # Required: the preceding `copy` ran with become: true and wrote
+  # the file as root@0600. Without become here the replace would
+  # hit permission denied on a non-root ansible_user.
+  become: true
+
+- name: set ~/.kube ownership
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.kube"
+    owner: "{{ ansible_user }}"
+    recurse: true
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+  become: true
+
 - name: check configured VF resources for built-in UPF
   block:
     - name: Get number of configured VFs for interface {{ core.data_iface }}

--- a/deps/5gc/roles/upf/tasks/install.yml
+++ b/deps/5gc/roles/upf/tasks/install.yml
@@ -41,6 +41,88 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
+# Ensure ~/.kube/config exists for the ansible user so kubernetes.core
+# tasks below find a valid config. See the 5gc/core role for the full
+# rationale and for why we only act when the file is absent.
+- name: check for existing ansible-user kubeconfig
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.kube/config"
+  register: _user_kubeconfig_stat
+  when: inventory_hostname in groups['master_nodes']
+
+- name: locate on-disk cluster kubeconfig
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - /etc/rancher/rke2/rke2.yaml
+    - /etc/rancher/k3s/k3s.yaml
+  register: _kubeconfig_candidates
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is not defined
+
+- name: resolve kubeconfig_source to first existing candidate
+  ansible.builtin.set_fact:
+    kubeconfig_source: "{{ item.item }}"
+  loop: "{{ _kubeconfig_candidates.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('') }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is not defined
+    - item.stat.exists | default(false)
+
+- name: ensure ~/.kube exists for ansible user
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.kube"
+    state: directory
+    mode: "0700"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+
+- name: install cluster kubeconfig at ~/.kube/config
+  ansible.builtin.copy:
+    src: "{{ kubeconfig_source }}"
+    dest: "{{ ansible_env.HOME }}/.kube/config"
+    remote_src: yes
+    mode: "0600"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+  become: true
+
+- name: rewrite 127.0.0.1 in kubeconfig when master is remote
+  ansible.builtin.replace:
+    path: "{{ ansible_env.HOME }}/.kube/config"
+    regexp: 'https://127\.0\.0\.1:6443'
+    replace: "https://{{ hostvars[groups['master_nodes'][0]]['ansible_host'] }}:6443"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+    - hostvars[groups['master_nodes'][0]]['ansible_host'] is defined
+    - hostvars[groups['master_nodes'][0]]['ansible_host'] != '127.0.0.1'
+  # Required: the preceding `copy` ran with become: true and wrote
+  # the file as root@0600. Without become here the replace would
+  # hit permission denied on a non-root ansible_user.
+  become: true
+
+- name: set ~/.kube ownership
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.kube"
+    owner: "{{ ansible_user }}"
+    recurse: true
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (_user_kubeconfig_stat.stat.exists | default(false))
+    - kubeconfig_source is defined
+  become: true
+
 - name: check configured VF resources for additional UPFs
   block:
     - name: Get number of configured VFs for interface {{ core.data_iface }}


### PR DESCRIPTION
Closes #179.

## Problem

`deps/k8s/roles/rke2/tasks/install.yml:320-350` populates `~/.kube/config` for the ansible user so later tasks that call `kubernetes.core.helm`, `kubernetes.core.k8s`, kubectl, or helm find a valid config. Operators who bring a pre-existing cluster — external RKE2/K3s, managed k8s, or a non-onramp bootstrap flow — skip the k8s role, so the kubeconfig-for-user setup never runs and the first 5gc task that calls helm fails with:

```
Error: Kubernetes cluster unreachable: Get "http://localhost:8080/version": dial tcp 127.0.0.1:8080: connect: connection refused
```

## Change

Add a defensive kubeconfig probe + install block at the top of the 5gc `core` and `upf` roles:

1. Probe `/etc/rancher/rke2/rke2.yaml`, then `/etc/rancher/k3s/k3s.yaml`.
2. Copy the first match to `{{ ansible_env.HOME }}/.kube/config` at mode `0600`, owned by the ansible user.
3. Skip cleanly when none is found (no-op, no failure) so standalone test flows that don't touch helm still work.

The copy is content-idempotent against the existing k8s role, so nothing changes for the full-onramp-flow case — the 5gc role's block will see the k8s role's output and be a no-op.

Operators with a non-standard kubeconfig location can override by setting `kubeconfig_source` in inventory vars, which skips the probe.

## Shape choice

The issue originally proposed extracting the shared logic into a standalone `roles/kubeconfig_for_user` + adding it to `roles_path`. I started down that path but walked it back — adding a top-level `roles/` dir and an `ansible.cfg` change is structural churn beyond what the stated problem needs, and it diverges from the "self-contained per-dep role" pattern every other role in this repo follows.

Instead, the block is inlined in each role that needs it (two files here). If a future refactor consolidates this, the airgap probe (#174), and the python3-kubernetes prereq (#178) into a shared location, that's probably the right time to pick up the original standalone-role shape — once a common pattern emerges from multiple sites.

## Affected roles

| Role                    | Uses `kubernetes.core` via   | Hits issue if k8s role skipped? |
|-------------------------|------------------------------|---------------------------------|
| `deps/5gc/roles/core`   | helm, k8s, k8s_info          | yes (reproduced)                |
| `deps/5gc/roles/upf`    | helm                         | yes                             |

Not included: `deps/4gc/roles/core`, `deps/amp/roles/*`, `deps/sdran/roles/*`. Those use `kubernetes.core` too, but they weren't the reproduced case; happy to extend the same pattern to them in a follow-up if you'd like to close the gap across the repo.

## Testing

- Full onramp flow (k8s role runs first): k8s role populates kubeconfig; 5gc block sees the same file, copy is a no-op; existing behaviour unchanged.
- Bring-your-own-cluster flow with only `/etc/rancher/rke2/rke2.yaml` present: 5gc block picks it up, writes `~/.kube/config`, helm tasks succeed.
- No cluster setup of any kind: 5gc block's `kubeconfig_source` stays undefined, all subsequent tasks in the block are skipped cleanly. The first `kubernetes.core.helm` call still fails — but with its own "cluster unreachable" error, same as before this PR, so no regression.