### PR TITLE
5gc core: replace synchronize with copy for local chart staging

### DIFF
--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -256,12 +256,17 @@
   when: inventory_hostname in groups['master_nodes']
 
 - name: copy local_charts to /tmp/sdcore-helm-charts
-  synchronize:
+  # Previously used ansible.posix.synchronize, which runs rsync as a
+  # controller-side subprocess. When the controller user differs from
+  # ansible_user (systemd service account, CI runner, sudo -u wrapper),
+  # the destination tree is owned by the controller user and the
+  # subsequent SSH-transported `helm dep up` task hits permission denied
+  # when it tries to populate the charts/ subdirectory. ansible.builtin.copy
+  # ships files through the normal Ansible connection, so they land owned
+  # by ansible_user. See opennetworkinglab/aether-onramp#190.
+  ansible.builtin.copy:
     src: "{{ local_sd_core_chart_root }}/"
-    dest: /tmp/sdcore-helm-charts
-    recursive: yes
-    rsync_opts:
-      - "--exclude=.git"
+    dest: /tmp/sdcore-helm-charts/
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
 - debug:


### PR DESCRIPTION
Fixes #190.

## Summary

`ansible.posix.synchronize` runs rsync as a controller-side subprocess, so the `/tmp/sdcore-helm-charts` tree is created owned by the controller user. When the controller user differs from `ansible_user` — systemd service account, CI runner, `sudo -u` wrapper — the next task (`helm dep up`, SSH-transported as `ansible_user`) hits `Error: mkdir /tmp/sdcore-helm-charts/<chart>/charts: permission denied`.

Replace the `synchronize` task with `ansible.builtin.copy`. `copy` ships files through the normal Ansible connection, so they land owned by `ansible_user` and the subsequent `helm dep up` succeeds without a chown fixup or a new sudoers prerequisite on the controller.

## Diff

One task, one file — `deps/5gc/roles/core/tasks/install.yml`:

- Drop: `synchronize` with `recursive: yes` + `rsync_opts: [--exclude=.git]`.
- Add: `ansible.builtin.copy` with the same `src`/`dest`.

## Tradeoffs

The issue lays out three approaches (A: `become_user` on synchronize, B: replace with `copy`, C: chown fixup after synchronize). This PR implements **B** because it's the shortest and requires no controller-side sudoers changes.

What's lost vs `synchronize`:
- `--exclude=.git` — `copy` will include the source's `.git` directory if present. For the chart tree this means a slightly larger staging copy; no correctness impact.
- Differential sync — `copy` re-transfers everything each run. Staging directory is `/tmp` and the chart tree is small; not a measurable cost in practice.

**I'm happy to rework this as Option A or Option C if you'd prefer either** — I just wanted to get something landed so the fix can be picked up downstream. Let me know what you'd like.

## Test plan

Reproduction playbook is in issue #190 — same failure before, clean run after. On a single-host deploy (`ansible_host=127.0.0.1`, `ansible_user=aether`) invoked from a non-`aether` controller user:

- Before: `TASK [core : update aether 5gc helm dependencies]` → `permission denied` on `mkdir .../charts`.
- After: task succeeds; `/tmp/sdcore-helm-charts` tree is owned by `aether:aether`.
