### PR TITLE
vars: unify airgapped config comment across main.yml and blueprints

### DIFF
--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-n3iwf.yml
+++ b/vars/main-n3iwf.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-ocudu.yml
+++ b/vars/main-ocudu.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -4,10 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml
-# for full documentation.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,17 +4,10 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Airgap behaviour for `apt: update_cache` tasks.
-#
-# When `enabled: true`, roles that touch apt (5gc/router, the docker
-# installs under srsran/ocudu/oai/n3iwf/gnbsim/oscric, ueransim/simulator,
-# amp/monitor, gnbsim/router, oai/router) skip `update_cache`. Set this
-# for offline / airgapped sites or for sites running off a local mirror
-# that does not need refresh from upstream. See the airgap section in
-# the README and the Aether Docs (https://docs.aetherproject.org/) for
-# operational details.
+# Skip `apt update_cache` in package-installing roles. Enable for
+# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
-  enabled: false                 # set true to skip `apt update_cache` (offline / mirror-only sites)
+  enabled: false
 
 k8s:
   rke2:


### PR DESCRIPTION
## Summary

The `airgapped` config key had two different comments across `vars/`:

- `vars/main.yml` carried a 9-line block explaining the flag, listing every role it affects, and linking to README / Aether Docs.
- The 12 `main-*.yml` blueprints carried a 2-line stub: *"Airgap behaviour for `apt: update_cache` tasks. See vars/main.yml for full documentation."*

Both versions also ended with a redundant inline trailer on `enabled: false`.

## Problems

1. **Blueprint-copy workflow loses context.** The manual onramp instructions tell operators to copy a blueprint over `vars/main.yml`. When they do that, the 9-line comment is replaced by the 2-line stub that points back at a file the operator just overwrote.
2. **Spurious comment diffs.** Comparing a blueprint to `main.yml` shows a comment-only diff even when no configuration changed, making real vs noise changes harder to spot in reviews.
3. **List rot.** The 9-line block enumerates every role that touches apt (`5gc/router`, `srsran/ocudu/oai/n3iwf/gnbsim/oscric` dockers, `ueransim/simulator`, `amp/monitor`, `gnbsim/router`, `oai/router`). This list drifts as roles are added and has to be updated everywhere it appears.

## Fix

Replace both variants with the same two-line self-contained comment in all 13 files, and drop the inline trailer that duplicated what the block already said:

```yaml
# Skip `apt update_cache` in package-installing roles. Enable for
# offline / airgapped sites or those backed by a local apt mirror.
airgapped:
  enabled: false
```

Result:

- Copying any blueprint over `main.yml` now produces no comment-level diff on this block.
- No per-role list to maintain; README / Aether Docs remain the right home for that detail.
- Comment is the same everywhere, so anyone reading a blueprint gets the essential context without the redirect.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open(f))"` run against all 13 files — all pass.
- `diff <(sed -n '7,10p' vars/main.yml) <(sed -n '7,10p' vars/main-*.yml)` produces no output for any blueprint.

## Note on review tooling

No Copilot review requested — this change is purely documentation (YAML comment edits), no behavioural diff. Please review by eye.