### PR TITLE
Reduce copy time by ignoring .git directory

### DIFF
--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -269,6 +269,7 @@
       register: core_local_chart_archive
       delegate_to: localhost
       become: false
+      run_once: true
 
     - name: archive local_charts without git metadata
       ansible.builtin.archive:
@@ -279,6 +280,15 @@
           - "{{ local_sd_core_chart_root }}/.git"
       delegate_to: localhost
       become: false
+      run_once: true
+
+    - name: publish local sd-core charts archive path
+      ansible.builtin.set_fact:
+        core_local_chart_archive_path: "{{ core_local_chart_archive.path }}"
+      delegate_to: localhost
+      delegate_facts: true
+      become: false
+      run_once: true
 
     - name: remove remote sd-core chart staging directory
       ansible.builtin.file:
@@ -293,16 +303,18 @@
 
     - name: unpack local_charts to /tmp/sdcore-helm-charts
       ansible.builtin.unarchive:
-        src: "{{ core_local_chart_archive.path }}"
+        src: "{{ hostvars['localhost'].core_local_chart_archive_path }}"
         dest: /tmp/sdcore-helm-charts/
 
+  always:
     - name: remove local sd-core charts archive
       ansible.builtin.file:
-        path: "{{ core_local_chart_archive.path }}"
+        path: "{{ hostvars['localhost'].core_local_chart_archive_path }}"
         state: absent
       delegate_to: localhost
       become: false
-      when: core_local_chart_archive.path is defined
+      run_once: true
+      when: hostvars['localhost'].core_local_chart_archive_path is defined
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
 - debug:

--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -256,17 +256,53 @@
   when: inventory_hostname in groups['master_nodes']
 
 - name: copy local_charts to /tmp/sdcore-helm-charts
-  # Previously used ansible.posix.synchronize, which runs rsync as a
-  # controller-side subprocess. When the controller user differs from
-  # ansible_user (systemd service account, CI runner, sudo -u wrapper),
-  # the destination tree is owned by the controller user and the
-  # subsequent SSH-transported `helm dep up` task hits permission denied
-  # when it tries to populate the charts/ subdirectory. ansible.builtin.copy
-  # ships files through the normal Ansible connection, so they land owned
-  # by ansible_user. See opennetworkinglab/aether-onramp#190.
-  ansible.builtin.copy:
-    src: "{{ local_sd_core_chart_root }}/"
-    dest: /tmp/sdcore-helm-charts/
+  # ansible.builtin.copy cannot exclude paths during recursive directory
+  # copies, so package the chart tree on the controller while omitting the
+  # local git metadata and then unarchive it on the target via the normal
+  # Ansible transport. This preserves ansible_user ownership on the remote
+  # host and avoids spending time traversing .git.
+  block:
+    - name: create local archive path for sd-core charts
+      ansible.builtin.tempfile:
+        state: file
+        suffix: .tar.gz
+      register: core_local_chart_archive
+      delegate_to: localhost
+      become: false
+
+    - name: archive local_charts without git metadata
+      ansible.builtin.archive:
+        path: "{{ local_sd_core_chart_root }}/"
+        dest: "{{ core_local_chart_archive.path }}"
+        format: gz
+        exclude_path:
+          - "{{ local_sd_core_chart_root }}/.git"
+      delegate_to: localhost
+      become: false
+
+    - name: remove remote sd-core chart staging directory
+      ansible.builtin.file:
+        path: /tmp/sdcore-helm-charts
+        state: absent
+
+    - name: create remote sd-core chart staging directory
+      ansible.builtin.file:
+        path: /tmp/sdcore-helm-charts
+        state: directory
+        mode: "0755"
+
+    - name: unpack local_charts to /tmp/sdcore-helm-charts
+      ansible.builtin.unarchive:
+        src: "{{ core_local_chart_archive.path }}"
+        dest: /tmp/sdcore-helm-charts/
+
+    - name: remove local sd-core charts archive
+      ansible.builtin.file:
+        path: "{{ core_local_chart_archive.path }}"
+        state: absent
+      delegate_to: localhost
+      become: false
+      when: core_local_chart_archive.path is defined
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
 - debug:

--- a/deps/5gc/roles/core/tasks/install.yml
+++ b/deps/5gc/roles/core/tasks/install.yml
@@ -309,12 +309,14 @@
   always:
     - name: remove local sd-core charts archive
       ansible.builtin.file:
-        path: "{{ hostvars['localhost'].core_local_chart_archive_path }}"
+        path: "{{ core_local_chart_archive.path }}"
         state: absent
       delegate_to: localhost
       become: false
       run_once: true
-      when: hostvars['localhost'].core_local_chart_archive_path is defined
+      when:
+        - core_local_chart_archive is defined
+        - core_local_chart_archive.path is defined
   when: inventory_hostname in groups['master_nodes'] and core.helm.local_charts
 
 - debug:


### PR DESCRIPTION
PR #193 replaced synchronize with copy for local chart staging due to a permissions/ownership issue. However, this change made that a deployment that uses local charts takes way much longer than before

As seen below, after #193 was merged, the majority of the time is spent in copying the local charts and a deployment that typically takes ~2 mins is now taking ~15 mins
```
Friday 24 April 2026  10:46:14 -0700 (0:01:00.065)       0:14:31.404 **********
===============================================================================
core : copy local_charts to /tmp/sdcore-helm-charts ----------------------------------------------------------- 753.58s
core : pause --------------------------------------------------------------------------------------------------- 60.07s
core : deploy aether 5gc --------------------------------------------------------------------------------------- 48.86s
core : install kubernetes.core python prerequisite (python3-kubernetes) ----------------------------------------- 2.02s
core : update aether 5gc helm dependencies ---------------------------------------------------------------------- 1.53s
Gathering Facts ------------------------------------------------------------------------------------------------- 1.44s
core : copy deps/5gc/roles/core/templates/sdcore-5g-values.yaml to /tmp/sdcore-5g-values.yaml ------------------- 0.54s
core : check local 5gc-cp chart dependencies -------------------------------------------------------------------- 0.51s
core : check for existing ansible-user kubeconfig --------------------------------------------------------------- 0.32s
core : remove /tmp/sdcore-5g-values.yaml ------------------------------------------------------------------------ 0.32s
core : Get number of configured VFs for interface eno12399np0 --------------------------------------------------- 0.31s
core : read local 5gc-cp Chart.yaml ----------------------------------------------------------------------------- 0.30s
core : find eno12399np0's subnet for RAN ------------------------------------------------------------------------ 0.27s
core : check local 5gc-cp charts directory ---------------------------------------------------------------------- 0.24s
core : set_fact ------------------------------------------------------------------------------------------------- 0.07s
core : validate ran_subnet is in valid CIDR format -------------------------------------------------------------- 0.07s
core : require manual 5gc-cp helm dependency update when charts are missing ------------------------------------- 0.06s
core : set_fact ------------------------------------------------------------------------------------------------- 0.06s
core : debug ---------------------------------------------------------------------------------------------------- 0.06s
core : debug ---------------------------------------------------------------------------------------------------- 0.06s
Playbook run took 0 days, 0 hours, 14 minutes, 31 seconds
```
The changes proposed in this PR keep the spirit of #193 (address ownership issue) but by only copying what is needed to reduce the deployment time to its old values.

```
Friday 24 April 2026  10:59:58 -0700 (0:01:00.070)       0:02:01.839 **********
===============================================================================
core : pause --------------------------------------------------------------------------------------------------- 60.07s
core : deploy aether 5gc --------------------------------------------------------------------------------------- 47.79s
core : install kubernetes.core python prerequisite (python3-kubernetes) ----------------------------------------- 2.81s
core : archive local_charts without git metadata ---------------------------------------------------------------- 2.35s
core : update aether 5gc helm dependencies ---------------------------------------------------------------------- 1.54s
Gathering Facts ------------------------------------------------------------------------------------------------- 1.48s
core : unpack local_charts to /tmp/sdcore-helm-charts ----------------------------------------------------------- 0.84s
core : copy deps/5gc/roles/core/templates/sdcore-5g-values.yaml to /tmp/sdcore-5g-values.yaml ------------------- 0.54s
core : check local 5gc-cp chart dependencies -------------------------------------------------------------------- 0.50s
core : check for existing ansible-user kubeconfig --------------------------------------------------------------- 0.33s
core : remove /tmp/sdcore-5g-values.yaml ------------------------------------------------------------------------ 0.33s
core : create local archive path for sd-core charts ------------------------------------------------------------- 0.32s
core : Get number of configured VFs for interface eno12399np0 --------------------------------------------------- 0.31s
core : read local 5gc-cp Chart.yaml ----------------------------------------------------------------------------- 0.30s
core : find eno12399np0's subnet for RAN ------------------------------------------------------------------------ 0.26s
core : remove local sd-core charts archive ---------------------------------------------------------------------- 0.25s
core : create remote sd-core chart staging directory ------------------------------------------------------------ 0.24s
core : check local 5gc-cp charts directory ---------------------------------------------------------------------- 0.23s
core : remove remote sd-core chart staging directory ------------------------------------------------------------ 0.22s
core : set_fact ------------------------------------------------------------------------------------------------- 0.07s
Playbook run took 0 days, 0 hours, 2 minutes, 1 seconds
```


