### PR TITLE
rke2: handle pre-existing installs and node-name fallback

### DIFF
--- a/deps/k8s/roles/rke2/defaults/main.yml
+++ b/deps/k8s/roles/rke2/defaults/main.yml
@@ -2,6 +2,7 @@ k8s:
   rke2:
     version: v1.35.3+rke2r3
     config:
+      preserve_existing: true
       token: aether-k8s-rke2
       port: 9345
       params_file:

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -32,6 +32,13 @@
 - set_fact:
     script_dir: /tmp/rke2
 
+- name: detect installed rke2 version
+  command: /usr/local/bin/rke2 --version
+  register: rke2_installed_version
+  changed_when: false
+  failed_when: false
+  become: true
+
 - name: build RKE2 installer environment
   set_fact:
     rke2_install_env: >-
@@ -44,16 +51,19 @@
             )
         )
       }}
+    rke2_install_needed: "{{ rke2_installed_version.rc != 0 or k8s.rke2.version not in (rke2_installed_version.stdout | default('')) }}"
 
 - name: remove {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: absent
+  when: rke2_install_needed
 
 - name: create {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: directory
+  when: rke2_install_needed
 
 - name: download rke2
   get_url:
@@ -61,6 +71,7 @@
     validate_certs: false
     dest: "{{ script_dir }}/install.sh"
     mode: "a+x"
+  when: rke2_install_needed
 
 - name: create /etc/rancher/rke2
   file:
@@ -72,23 +83,36 @@
   command:
     argv:
       - "{{ script_dir }}/install.sh"
-  environment: "{{ rke2_install_env }}"
-  when: inventory_hostname in groups['master_nodes']
+  environment: "{{ rke2_install_env | combine({'INSTALL_RKE2_SKIP_ENABLE': 'true', 'INSTALL_RKE2_SKIP_START': 'true'}) }}"
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - rke2_install_needed
   become: true
 
 - name: enable rke2-server on masters
   systemd:
     name: rke2-server
     enabled: true
+    daemon_reload: true
   when: inventory_hostname in groups['master_nodes']
   become: true
 
 # TODO: fix multi-master issue (tls-san)
+- name: check for existing /etc/rancher/rke2/config.yaml
+  stat:
+    path: /etc/rancher/rke2/config.yaml
+  register: rke2_existing_config
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
 - name: copy master-config.yaml to /etc/rancher/rke2/config.yaml
   template:
     src: "{{ ROOT_DIR }}/{{ k8s.rke2.config.params_file.master }}"
     dest: /etc/rancher/rke2/config.yaml
-  when: inventory_hostname in groups['master_nodes']
+  register: rke2_server_config
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (rke2_existing_config.stat.exists | default(false))
   become: true
 
 - name: configure proxy for rke2-server
@@ -128,13 +152,14 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: restart rke2-server after proxy configuration change
+- name: restart rke2-server after configuration change
   systemd:
     name: rke2-server
     state: restarted
   when:
     - inventory_hostname in groups['master_nodes']
-    - (rke2_server_proxy_present is defined and rke2_server_proxy_present is changed) or
+    - (rke2_server_config is defined and rke2_server_config is changed) or
+      (rke2_server_proxy_present is defined and rke2_server_proxy_present is changed) or
       (rke2_server_proxy_absent is defined and rke2_server_proxy_absent is changed)
   become: true
 
@@ -163,6 +188,22 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
+- name: read node-name from rke2 config
+  command: grep '^node-name:' /etc/rancher/rke2/config.yaml
+  register: rke2_config_node_name_line
+  changed_when: false
+  failed_when: false
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
+- name: resolve expected node name
+  set_fact:
+    rke2_expected_node_name: >-
+      {{ (rke2_config_node_name_line.stdout | default('') | regex_replace('^node-name:\s*', '') | trim)
+         if (rke2_config_node_name_line.rc | default(1)) == 0 and (rke2_config_node_name_line.stdout | default('') | trim) != ''
+         else inventory_hostname }}
+  when: inventory_hostname in groups['master_nodes']
+
 - name: wait for this master node object to be registered
   command:
     argv:
@@ -171,7 +212,7 @@
       - /etc/rancher/rke2/rke2.yaml
       - get
       - node
-      - "{{ inventory_hostname }}"
+      - "{{ rke2_expected_node_name }}"
       - -o
       - name
   register: rke2_current_node
@@ -254,14 +295,24 @@
   command:
     argv:
       - "{{ script_dir }}/install.sh"
-  environment: "{{ rke2_install_env | combine({'INSTALL_RKE2_TYPE': 'agent'}) }}"
-  when: inventory_hostname in groups['worker_nodes']
+  environment: "{{ rke2_install_env | combine({'INSTALL_RKE2_TYPE': 'agent', 'INSTALL_RKE2_SKIP_ENABLE': 'true', 'INSTALL_RKE2_SKIP_START': 'true'}) }}"
+  when:
+    - inventory_hostname in groups['worker_nodes']
+    - rke2_install_needed
   become: true
 
 - name: enable rke2-agent on workers
   systemd:
     name: rke2-agent
     enabled: true
+    daemon_reload: true
+  when: inventory_hostname in groups['worker_nodes']
+  become: true
+
+- name: check for existing /etc/rancher/rke2/config.yaml on workers
+  stat:
+    path: /etc/rancher/rke2/config.yaml
+  register: rke2_existing_worker_config
   when: inventory_hostname in groups['worker_nodes']
   become: true
 
@@ -269,7 +320,10 @@
   template:
     src: "{{ ROOT_DIR }}/{{ k8s.rke2.config.params_file.worker }}"
     dest: /etc/rancher/rke2/config.yaml
-  when: inventory_hostname in groups['worker_nodes']
+  register: rke2_agent_config
+  when:
+    - inventory_hostname in groups['worker_nodes']
+    - not (rke2_existing_worker_config.stat.exists | default(false))
   become: true
 
 - name: configure proxy for rke2-agent
@@ -310,14 +364,15 @@
   when: inventory_hostname in groups['worker_nodes']
   become: true
 
-- name: restart rke2-agent after proxy configuration change
+- name: restart rke2-agent after configuration change
   systemd:
     name: rke2-agent
     state: restarted
   throttle: 1
   when:
     - inventory_hostname in groups['worker_nodes']
-    - (rke2_agent_proxy_present is defined and rke2_agent_proxy_present is changed) or
+    - (rke2_agent_config is defined and rke2_agent_config is changed) or
+      (rke2_agent_proxy_present is defined and rke2_agent_proxy_present is changed) or
       (rke2_agent_proxy_absent is defined and rke2_agent_proxy_absent is changed)
   become: true
 

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -188,20 +188,23 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: read node-name from rke2 config
-  command: grep '^node-name:' /etc/rancher/rke2/config.yaml
-  register: rke2_config_node_name_line
+- name: read rke2 config
+  slurp:
+    path: /etc/rancher/rke2/config.yaml
+  register: rke2_config_raw
   changed_when: false
-  failed_when: false
   when: inventory_hostname in groups['master_nodes']
   become: true
+
+- name: parse rke2 config
+  set_fact:
+    rke2_config_parsed: "{{ (rke2_config_raw.content | b64decode | from_yaml) | default({}, true) }}"
+  when: inventory_hostname in groups['master_nodes']
 
 - name: resolve expected node name
   set_fact:
     rke2_expected_node_name: >-
-      {{ (rke2_config_node_name_line.stdout | default('') | regex_replace('^node-name:\s*', '') | trim)
-         if (rke2_config_node_name_line.rc | default(1)) == 0 and (rke2_config_node_name_line.stdout | default('') | trim) != ''
-         else (ansible_hostname | default(inventory_hostname)) }}
+      {{ rke2_config_parsed['node-name'] | default(ansible_hostname | default(inventory_hostname)) }}
   when: inventory_hostname in groups['master_nodes']
 
 - name: wait for this master node object to be registered

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -32,11 +32,21 @@
 - set_fact:
     script_dir: /tmp/rke2
 
+- name: check for installed rke2 binary
+  stat:
+    path: /usr/local/bin/rke2
+  register: rke2_binary
+  when: inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
+  become: true
+
 - name: detect installed rke2 version
   command: /usr/local/bin/rke2 --version
   register: rke2_installed_version
   changed_when: false
-  failed_when: false
+  when:
+    - inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
+    - rke2_binary.stat.exists
+    - rke2_binary.stat.executable
   become: true
 
 - name: build RKE2 installer environment
@@ -51,19 +61,32 @@
             )
         )
       }}
-    rke2_install_needed: "{{ rke2_installed_version.rc != 0 or k8s.rke2.version not in (rke2_installed_version.stdout | default('')) }}"
+    rke2_install_needed: >-
+      {{
+        not (rke2_binary.stat.exists | default(false) and rke2_binary.stat.executable | default(false))
+        or (
+          (k8s.rke2.version is search('\\+rke2r'))
+          and (((rke2_installed_version.stdout_lines[0] | default('')) | regex_search('v[^ ]+') | default('', true)) != k8s.rke2.version)
+        )
+        or (k8s.rke2.version is not search('\\+rke2r'))
+      }}
+  when: inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
 
 - name: remove {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: absent
-  when: rke2_install_needed
+  when:
+    - inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
+    - rke2_install_needed
 
 - name: create {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: directory
-  when: rke2_install_needed
+  when:
+    - inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
+    - rke2_install_needed
 
 - name: download rke2
   get_url:
@@ -71,12 +94,15 @@
     validate_certs: false
     dest: "{{ script_dir }}/install.sh"
     mode: "a+x"
-  when: rke2_install_needed
+  when:
+    - inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
+    - rke2_install_needed
 
 - name: create /etc/rancher/rke2
   file:
     path: "/etc/rancher/rke2"
     state: directory
+  when: inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
   become: true
 
 - name: install rke2 on masters
@@ -84,6 +110,7 @@
     argv:
       - "{{ script_dir }}/install.sh"
   environment: "{{ rke2_install_env | combine({'INSTALL_RKE2_SKIP_ENABLE': 'true', 'INSTALL_RKE2_SKIP_START': 'true'}) }}"
+  register: rke2_server_install
   when:
     - inventory_hostname in groups['master_nodes']
     - rke2_install_needed
@@ -93,7 +120,6 @@
   systemd:
     name: rke2-server
     enabled: true
-    daemon_reload: true
   when: inventory_hostname in groups['master_nodes']
   become: true
 
@@ -112,7 +138,7 @@
   register: rke2_server_config
   when:
     - inventory_hostname in groups['master_nodes']
-    - not (rke2_existing_config.stat.exists | default(false))
+    - not (rke2_existing_config.stat.exists and (k8s.rke2.config.preserve_existing | default(true)))
   become: true
 
 - name: configure proxy for rke2-server
@@ -158,7 +184,8 @@
     state: restarted
   when:
     - inventory_hostname in groups['master_nodes']
-    - (rke2_server_config is defined and rke2_server_config is changed) or
+    - (rke2_server_install is defined and rke2_server_install is changed) or
+      (rke2_server_config is defined and rke2_server_config is changed) or
       (rke2_server_proxy_present is defined and rke2_server_proxy_present is changed) or
       (rke2_server_proxy_absent is defined and rke2_server_proxy_absent is changed)
   become: true
@@ -188,23 +215,38 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: read rke2 config
-  slurp:
-    path: /etc/rancher/rke2/config.yaml
-  register: rke2_config_raw
+- name: read system hostname
+  command: hostname
+  register: rke2_system_hostname
   changed_when: false
   when: inventory_hostname in groups['master_nodes']
   become: true
 
-- name: parse rke2 config
-  set_fact:
-    rke2_config_parsed: "{{ (rke2_config_raw.content | b64decode | from_yaml) | default({}, true) }}"
+- block:
+    - name: read rke2 config
+      slurp:
+        path: /etc/rancher/rke2/config.yaml
+      register: rke2_config_raw
+      changed_when: false
+      become: true
+
+    - name: parse rke2 config
+      set_fact:
+        rke2_config_parsed: "{{ (rke2_config_raw.content | b64decode | from_yaml) | default({}, true) }}"
+  rescue:
+    - name: fall back when rke2 config cannot be parsed
+      set_fact:
+        rke2_config_parsed: {}
   when: inventory_hostname in groups['master_nodes']
 
 - name: resolve expected node name
   set_fact:
     rke2_expected_node_name: >-
-      {{ rke2_config_parsed['node-name'] | default(ansible_hostname | default(inventory_hostname)) }}
+      {{
+        rke2_config_parsed.get('node-name')
+        if (rke2_config_parsed.get('node-name') is string and (rke2_config_parsed.get('node-name') | trim) != '')
+        else ((rke2_system_hostname.stdout | default('') | trim) or inventory_hostname)
+      }}
   when: inventory_hostname in groups['master_nodes']
 
 - name: wait for this master node object to be registered
@@ -299,6 +341,7 @@
     argv:
       - "{{ script_dir }}/install.sh"
   environment: "{{ rke2_install_env | combine({'INSTALL_RKE2_TYPE': 'agent', 'INSTALL_RKE2_SKIP_ENABLE': 'true', 'INSTALL_RKE2_SKIP_START': 'true'}) }}"
+  register: rke2_agent_install
   when:
     - inventory_hostname in groups['worker_nodes']
     - rke2_install_needed
@@ -308,7 +351,6 @@
   systemd:
     name: rke2-agent
     enabled: true
-    daemon_reload: true
   when: inventory_hostname in groups['worker_nodes']
   become: true
 
@@ -326,7 +368,7 @@
   register: rke2_agent_config
   when:
     - inventory_hostname in groups['worker_nodes']
-    - not (rke2_existing_worker_config.stat.exists | default(false))
+    - not (rke2_existing_worker_config.stat.exists and (k8s.rke2.config.preserve_existing | default(true)))
   become: true
 
 - name: configure proxy for rke2-agent
@@ -374,7 +416,8 @@
   throttle: 1
   when:
     - inventory_hostname in groups['worker_nodes']
-    - (rke2_agent_config is defined and rke2_agent_config is changed) or
+    - (rke2_agent_install is defined and rke2_agent_install is changed) or
+      (rke2_agent_config is defined and rke2_agent_config is changed) or
       (rke2_agent_proxy_present is defined and rke2_agent_proxy_present is changed) or
       (rke2_agent_proxy_absent is defined and rke2_agent_proxy_absent is changed)
   become: true

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -46,7 +46,7 @@
   when:
     - inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
     - rke2_binary.stat.exists
-    - rke2_binary.stat.executable
+    - rke2_binary.stat.executable | default(false)
   become: true
 
 - name: build RKE2 installer environment
@@ -244,7 +244,11 @@
     rke2_expected_node_name: >-
       {{
         rke2_config_parsed.get('node-name')
-        if (rke2_config_parsed.get('node-name') is string and (rke2_config_parsed.get('node-name') | trim) != '')
+        if (
+          rke2_config_parsed is mapping and
+          rke2_config_parsed.get('node-name') is string and
+          (rke2_config_parsed.get('node-name') | trim) != ''
+        )
         else ((rke2_system_hostname.stdout | default('') | trim) or inventory_hostname)
       }}
   when: inventory_hostname in groups['master_nodes']

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -201,7 +201,7 @@
     rke2_expected_node_name: >-
       {{ (rke2_config_node_name_line.stdout | default('') | regex_replace('^node-name:\s*', '') | trim)
          if (rke2_config_node_name_line.rc | default(1)) == 0 and (rke2_config_node_name_line.stdout | default('') | trim) != ''
-         else inventory_hostname }}
+         else (ansible_hostname | default(inventory_hostname)) }}
   when: inventory_hostname in groups['master_nodes']
 
 - name: wait for this master node object to be registered

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -229,14 +229,17 @@
       register: rke2_config_raw
       changed_when: false
       become: true
+      no_log: true
 
     - name: parse rke2 config
       set_fact:
         rke2_config_parsed: "{{ (rke2_config_raw.content | b64decode | from_yaml) | default({}, true) }}"
+      no_log: true
   rescue:
     - name: fall back when rke2 config cannot be parsed
       set_fact:
         rke2_config_parsed: {}
+      no_log: true
   when: inventory_hostname in groups['master_nodes']
 
 - name: resolve expected node name


### PR DESCRIPTION
## What this fixes

This improves the RKE2 role for cases where Kubernetes is already present on the host.

The main issue is the node readiness check. When `/etc/rancher/rke2/config.yaml` does not set `node-name`, RKE2 defaults to the system hostname. In that case `inventory_hostname` from `hosts.ini` can be something like `localhost` or `node01`, and the role ends up waiting on the wrong Kubernetes node name.

## What changed

- make the RKE2 install path idempotent when the desired pinned version is already installed
- avoid re-downloading / re-running the installer when it is not needed
- restart RKE2 when the installer actually updates the binary
- add an explicit `k8s.rke2.config.preserve_existing` setting and default it to `true`
- preserve an existing `/etc/rancher/rke2/config.yaml` instead of overwriting it when that setting is enabled
- resolve the expected node name from `config.yaml` when `node-name` is set
- fall back to the live system hostname when `node-name` is not set
- parse `config.yaml` as YAML instead of grepping for `node-name`
- make config parsing non-fatal so the hostname fallback still works if the file is malformed

## Why this helps

For externally bootstrapped or pre-existing RKE2 installs, the role now uses the actual node name that RKE2 will register, so the readiness check does not fail just because the inventory alias differs from the hostname.

It also makes re-runs cleaner and faster when the desired RKE2 version is already present.

Happy to adjust this if there is a better preferred pattern for handling pre-existing RKE2 installs or for resolving the node name.
