### PR TITLE
k8s: make rke2/helm install gates airgap-safe no-ops

### DIFF
--- a/deps/k8s/roles/helm/tasks/install.yml
+++ b/deps/k8s/roles/helm/tasks/install.yml
@@ -15,9 +15,7 @@
   register: helm_installed_version
   changed_when: false
   failed_when: false
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - helm_binary.stat.exists | default(false)
+  when: inventory_hostname in groups['master_nodes'] and (helm_binary.stat.exists | default(false))
   become: true
 
 - name: determine if helm install is needed
@@ -33,17 +31,13 @@
   file:
     path: "{{ script_dir }}"
     state: absent
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - helm_install_needed
+  when: inventory_hostname in groups['master_nodes'] and (helm_install_needed | default(false))
 
 - name: create {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: directory
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - helm_install_needed
+  when: inventory_hostname in groups['master_nodes'] and (helm_install_needed | default(false))
 
 - name: download get-helm.sh
   get_url:
@@ -51,16 +45,12 @@
     validate_certs: true
     dest: "{{ script_dir }}/get-helm.sh"
     mode: "a+x"
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - helm_install_needed
+  when: inventory_hostname in groups['master_nodes'] and (helm_install_needed | default(false))
 
 - name: install helm on masters
   command:
     argv:
       - "{{ script_dir }}/get-helm.sh"
   environment: "{{ proxy_env | combine({'DESIRED_VERSION': k8s.helm.version}) }}"
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - helm_install_needed
+  when: inventory_hostname in groups['master_nodes'] and (helm_install_needed | default(false))
   become: true

--- a/deps/k8s/roles/helm/tasks/install.yml
+++ b/deps/k8s/roles/helm/tasks/install.yml
@@ -3,17 +3,47 @@
 - set_fact:
     script_dir: /tmp/helm
 
+- name: check for installed helm binary
+  stat:
+    path: /usr/local/bin/helm
+  register: helm_binary
+  when: inventory_hostname in groups['master_nodes']
+  become: true
+
+- name: detect installed helm version
+  command: /usr/local/bin/helm version --short
+  register: helm_installed_version
+  changed_when: false
+  failed_when: false
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - helm_binary.stat.exists | default(false)
+  become: true
+
+- name: determine if helm install is needed
+  set_fact:
+    helm_install_needed: >-
+      {{
+        not (helm_binary.stat.exists | default(false))
+        or (k8s.helm.version not in (helm_installed_version.stdout | default('')))
+      }}
+  when: inventory_hostname in groups['master_nodes']
+
 - name: remove {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - helm_install_needed
 
 - name: create {{ script_dir }}
   file:
     path: "{{ script_dir }}"
     state: directory
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - helm_install_needed
 
 - name: download get-helm.sh
   get_url:
@@ -21,12 +51,16 @@
     validate_certs: true
     dest: "{{ script_dir }}/get-helm.sh"
     mode: "a+x"
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - helm_install_needed
 
 - name: install helm on masters
   command:
     argv:
       - "{{ script_dir }}/get-helm.sh"
   environment: "{{ proxy_env | combine({'DESIRED_VERSION': k8s.helm.version}) }}"
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - helm_install_needed
   become: true

--- a/deps/k8s/roles/rke2/tasks/install.yml
+++ b/deps/k8s/roles/rke2/tasks/install.yml
@@ -54,21 +54,16 @@
     rke2_install_env: >-
       {{
         proxy_env | combine(
-          (k8s.rke2.version is search('\\+rke2r'))
-          | ternary(
-              {'INSTALL_RKE2_VERSION': k8s.rke2.version},
-              {'INSTALL_RKE2_CHANNEL': k8s.rke2.version}
-            )
+          {'INSTALL_RKE2_VERSION': k8s.rke2.version}
+          if '+rke2r' in k8s.rke2.version
+          else {'INSTALL_RKE2_CHANNEL': k8s.rke2.version}
         )
       }}
     rke2_install_needed: >-
       {{
         not (rke2_binary.stat.exists | default(false) and rke2_binary.stat.executable | default(false))
-        or (
-          (k8s.rke2.version is search('\\+rke2r'))
-          and (((rke2_installed_version.stdout_lines[0] | default('')) | regex_search('v[^ ]+') | default('', true)) != k8s.rke2.version)
-        )
-        or (k8s.rke2.version is not search('\\+rke2r'))
+        or ('+rke2r' not in k8s.rke2.version)
+        or (k8s.rke2.version not in (rke2_installed_version.stdout | default('')))
       }}
   when: inventory_hostname in (groups['master_nodes'] + groups['worker_nodes'])
 


### PR DESCRIPTION
## Summary

Two related fixes that turn `make aether-k8s-install` into a true no-op when RKE2 and Helm are already at the desired versions — required for airgap reruns where the install scripts can't be fetched.

### `rke2: fix install gate so version comparison actually skips when matched`

The `set_fact` gate at `deps/k8s/roles/rke2/tasks/install.yml:52` had two regex bugs that combined to force a reinstall every run:

- `is search('\\+rke2r')` — in a YAML folded scalar (`>-`) the backslashes are literal, so Jinja sees `\\+rke2r` and `re.search` interprets `\\+` as "one or more literal backslashes." Never matches the version string. The ternary therefore always took the channel branch, setting `INSTALL_RKE2_CHANNEL=v1.x.y+rke2r…` (an invalid channel).
- `regex_search('v[^ ]+')` against `rke2 --version` output — first match of `v + non-space` in `rke2 version v1.35.3+rke2r3 (sha)` is the literal word `version`, not the version. The comparison `'version' != 'v1.35.3+rke2r3'` is always true.

Net effect: every run hit `https://get.rke2.io` for `install.sh`, which fails on airgapped hosts. Replaced both with substring `in`/`not in` operations that don't depend on regex/escape interpretation. Channel mode (`INSTALL_RKE2_CHANNEL`) is preserved.

### `helm: gate install on existing version so airgap reruns are no-ops`

Helm role unconditionally wiped `/tmp/helm` and re-fetched `get-helm-3` from `raw.githubusercontent.com` on every run. Mirrored the rke2 role's gating: stat `/usr/local/bin/helm`, read `helm version --short`, and skip the download/install when the desired version is already a substring of the installed output.

## Test plan

Verified on a real airgapped Ubuntu 24.04 host (LXD VM, no internet) with RKE2 v1.35.3+rke2r3 and Helm v3.20.0 already staged.

Before: `download rke2` failed with name resolution / `download get-helm.sh` failed with network unreachable.

After:
- [x] `make aether-k8s-install` exits 0
- [x] RKE2 stage: `PLAY RECAP — ok=27 changed=0 unreachable=0 failed=0 skipped=18` (download/install/start tasks all skip; kubectl/kubeconfig copy still run)
- [x] Helm stage: `PLAY RECAP — ok=5 changed=0 unreachable=0 failed=0 skipped=4` (only stat + version-detect + gate eval run)
- [x] `yaml.safe_load` parses both files
- [x] `ansible-playbook --syntax-check` passes for `deps/k8s/rke2.yml` and `deps/k8s/helm.yml`

DCO: both commits are signed off.