### PR TITLE
Airgap cache protection: gate network ops + preserve cached state on stop/uninstall

### DIFF
--- a/deps/amp/roles/monitor/tasks/install.yml
+++ b/deps/amp/roles/monitor/tasks/install.yml
@@ -71,10 +71,16 @@
   become: true
 
 - name: add rancher chart repo
+  # Adding a remote helm repo hits the network at registration. In
+  # airgap mode operators must pre-stage chart artifacts via the
+  # bundle; skip the network add. Downstream helm install tasks
+  # would still need a local equivalent of this chart available.
   kubernetes.core.helm_repository:
     name: rancher
     repo_url: "https://charts.rancher.io"
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (airgapped.enabled | default(false) | bool)
 
 - name: remove /tmp/monitor-values.yaml
   file:

--- a/deps/amp/roles/monitor/tasks/install.yml
+++ b/deps/amp/roles/monitor/tasks/install.yml
@@ -70,17 +70,37 @@
   when: inventory_hostname in groups['master_nodes'] and UBUNTU_VERSION is version_compare('24.04', '>=')
   become: true
 
+# Short-circuit the rest of the role in airgap mode. The downstream
+# tasks register a remote `helm_repository` and deploy
+# `rancher-monitoring-crd` plus `rancher-monitoring` from the
+# rancher chart repo with `update_repo_cache: true`. The bundle
+# does not vendor those charts today, so partial gating would
+# leave the role half-applied with confusing follow-on errors.
+# Surface the limitation explicitly and skip cleanly.
+- name: notice | amp/monitor has no airgap support yet
+  ansible.builtin.debug:
+    msg: |
+      amp/monitor is not supported in airgap mode today. The role
+      registers the rancher helm repo and deploys
+      rancher-monitoring-crd / rancher-monitoring from network
+      sources the bundle does not vendor. Skipping the rest of
+      this role on this host. Set `airgapped.enabled: false` to
+      deploy AMP monitoring online.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - airgapped.enabled | default(false) | bool
+
+- name: end host | airgap mode short-circuits amp/monitor
+  ansible.builtin.meta: end_host
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - airgapped.enabled | default(false) | bool
+
 - name: add rancher chart repo
-  # Adding a remote helm repo hits the network at registration. In
-  # airgap mode operators must pre-stage chart artifacts via the
-  # bundle; skip the network add. Downstream helm install tasks
-  # would still need a local equivalent of this chart available.
   kubernetes.core.helm_repository:
     name: rancher
     repo_url: "https://charts.rancher.io"
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - not (airgapped.enabled | default(false) | bool)
+  when: inventory_hostname in groups['master_nodes']
 
 - name: remove /tmp/monitor-values.yaml
   file:

--- a/deps/amp/roles/roc/tasks/install.yml
+++ b/deps/amp/roles/roc/tasks/install.yml
@@ -15,14 +15,25 @@
   become: true
 
 - name: add atomix chart repo
+  # Adding a remote helm repo hits the network at registration. In
+  # airgap mode the operator is expected to pre-stage atomix and
+  # other chart artifacts via the bundle; skip the network add.
+  # Downstream helm install tasks would still need a local
+  # equivalent of this chart available for amp/roc to come up.
   kubernetes.core.helm_repository:
     name: atomix
     repo_url: "https://atomix.github.io/charts.atomix.io"
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (airgapped.enabled | default(false) | bool)
 
 # TODO: add a local check to install local store
 # TODO: use kubectl module for ansible
 - name: apply local-path provisioner manifest
+  # `kubectl apply -f https://...` fetches the manifest from
+  # raw.githubusercontent.com at run time. In airgap mode the
+  # operator must pre-stage the manifest locally and apply it
+  # out-of-band; skip the network fetch here.
   command:
     argv:
       - kubectl
@@ -30,7 +41,9 @@
       - -f
       - "https://raw.githubusercontent.com/rancher/local-path-provisioner/{{ amp.store.lpp.version }}/deploy/local-path-storage.yaml"
       - --wait=true
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (airgapped.enabled | default(false) | bool)
 
 - name: patch local-path storage class as default
   command:

--- a/deps/amp/roles/roc/tasks/install.yml
+++ b/deps/amp/roles/roc/tasks/install.yml
@@ -14,26 +14,43 @@
   when: inventory_hostname in groups['master_nodes']
   become: true
 
+# Short-circuit the rest of the role in airgap mode. The downstream
+# tasks register a remote `helm_repository`, fetch a local-path
+# manifest from raw.githubusercontent.com, run `helm dep up`, and
+# deploy three OCI / HTTPS-hosted charts (atomix, onos-operator,
+# aether-roc-umbrella) with `update_repo_cache: true`. None of
+# those have a local-charts path today, so partial gating would
+# leave the role half-applied with confusing follow-on errors.
+# Surface the limitation explicitly and skip cleanly. When bundle
+# support for these charts lands, the early-exit can be relaxed.
+- name: notice | amp/roc has no airgap support yet
+  ansible.builtin.debug:
+    msg: |
+      amp/roc is not supported in airgap mode today. The role
+      registers a remote helm repo, fetches a manifest over
+      HTTPS, and deploys charts (atomix, onos-operator,
+      aether-roc-umbrella) from network sources the bundle does
+      not vendor. Skipping the rest of this role on this host.
+      Set `airgapped.enabled: false` to deploy ROC online.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - airgapped.enabled | default(false) | bool
+
+- name: end host | airgap mode short-circuits amp/roc
+  ansible.builtin.meta: end_host
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - airgapped.enabled | default(false) | bool
+
 - name: add atomix chart repo
-  # Adding a remote helm repo hits the network at registration. In
-  # airgap mode the operator is expected to pre-stage atomix and
-  # other chart artifacts via the bundle; skip the network add.
-  # Downstream helm install tasks would still need a local
-  # equivalent of this chart available for amp/roc to come up.
   kubernetes.core.helm_repository:
     name: atomix
     repo_url: "https://atomix.github.io/charts.atomix.io"
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - not (airgapped.enabled | default(false) | bool)
+  when: inventory_hostname in groups['master_nodes']
 
 # TODO: add a local check to install local store
 # TODO: use kubectl module for ansible
 - name: apply local-path provisioner manifest
-  # `kubectl apply -f https://...` fetches the manifest from
-  # raw.githubusercontent.com at run time. In airgap mode the
-  # operator must pre-stage the manifest locally and apply it
-  # out-of-band; skip the network fetch here.
   command:
     argv:
       - kubectl
@@ -41,9 +58,7 @@
       - -f
       - "https://raw.githubusercontent.com/rancher/local-path-provisioner/{{ amp.store.lpp.version }}/deploy/local-path-storage.yaml"
       - --wait=true
-  when:
-    - inventory_hostname in groups['master_nodes']
-    - not (airgapped.enabled | default(false) | bool)
+  when: inventory_hostname in groups['master_nodes']
 
 - name: patch local-path storage class as default
   command:

--- a/deps/gnbsim/roles/docker/tasks/install.yml
+++ b/deps/gnbsim/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['gnbsim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['gnbsim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/gnbsim/roles/docker/tasks/start.yml
+++ b/deps/gnbsim/roles/docker/tasks/start.yml
@@ -1,9 +1,11 @@
 ---
 
-- name: pull {{ gnbsim.docker.container.image }} image
+- name: ensure {{ gnbsim.docker.container.image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ gnbsim.docker.container.image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 

--- a/deps/gnbsim/roles/docker/tasks/stop.yml
+++ b/deps/gnbsim/roles/docker/tasks/stop.yml
@@ -16,10 +16,24 @@
   when: inventory_hostname in groups['gnbsim_nodes']
   become: true
 
+- name: notice | preserve {{ gnbsim.docker.container.image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ gnbsim.docker.container.image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['gnbsim_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ gnbsim.docker.container.image }} image
   community.docker.docker_image:
     name: "{{ gnbsim.docker.container.image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['gnbsim_nodes']
+  when:
+    - inventory_hostname in groups['gnbsim_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/k8s/roles/helm/tasks/uninstall.yml
+++ b/deps/k8s/roles/helm/tasks/uninstall.yml
@@ -3,11 +3,28 @@
 - set_fact:
     script_dir: /tmp/helm
 
+- name: notice | preserve helm binary in airgap mode
+  # In airgap mode the helm binary at /usr/local/bin/helm came
+  # from the bundle's helm component. Removing it forces a
+  # network-bound reinstall. Default behaviour is to leave the
+  # binary in place; operators can opt in with allow_purge.
+  debug:
+    msg: |
+      Skipping helm binary removal to preserve the airgap install
+      cache. Re-run with `-e airgapped.allow_purge=true` to remove
+      /usr/local/bin/helm as well.
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove /usr/local/bin/helm
   file:
     path: "/usr/local/bin/helm"
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true
 
 - name: remove {{ script_dir }}

--- a/deps/k8s/roles/rke2/tasks/uninstall.yml
+++ b/deps/k8s/roles/rke2/tasks/uninstall.yml
@@ -1,5 +1,24 @@
 ---
 
+- name: notice | preserve RKE2 + image cache in airgap mode
+  # rke2-uninstall.sh wipes /var/lib/rancher, which holds the
+  # bundled containerd image dir an airgap reinstall depends on.
+  # Default airgap behaviour is to leave rke2 in place; operators
+  # can force a full uninstall by setting `airgapped.allow_purge`.
+  debug:
+    msg: |
+      Skipping rke2 uninstall to preserve the airgap install cache
+      (containerd image dir, bundled binaries, /var/lib/rancher).
+      Re-running install would otherwise re-stage everything from
+      the bundle, but only the operator can decide whether the host
+      is being decommissioned. To proceed with a full uninstall,
+      re-run with `-e airgapped.allow_purge=true`.
+  when:
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
+# ~/.kube is just kubeconfig — small, easy to recreate, and gets
+# rewritten by the install role regardless. Always remove it.
 - name: delete {{ ansible_env.HOME }}/.kube
   file:
     path: "{{ ansible_env.HOME }}/.kube"
@@ -10,7 +29,9 @@
   file:
     path: "/usr/local/bin/kubectl"
     state: absent
-  when: inventory_hostname in groups['master_nodes']
+  when:
+    - inventory_hostname in groups['master_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true
 
 - set_fact:
@@ -18,6 +39,8 @@
 
 - name: uninstall rke2 masters/workers
   command: "/usr/local/bin/rke2-uninstall.sh"
+  when:
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true
   ignore_errors: yes
 

--- a/deps/n3iwf/roles/docker/tasks/install.yml
+++ b/deps/n3iwf/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['n3iwf_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['n3iwf_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/n3iwf/roles/n3iwf/tasks/start.yml
+++ b/deps/n3iwf/roles/n3iwf/tasks/start.yml
@@ -16,10 +16,12 @@
     preflight_enabled: "{{ n3iwf.docker.preflight.enabled }}"
   when: inventory_hostname in groups['n3iwf_nodes']
 
-- name: pull {{ n3iwf.docker.image }} image
+- name: ensure {{ n3iwf.docker.image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ n3iwf.docker.image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['n3iwf_nodes']
   become: true
 

--- a/deps/n3iwf/roles/n3iwf/tasks/stop.yml
+++ b/deps/n3iwf/roles/n3iwf/tasks/stop.yml
@@ -28,10 +28,24 @@
   when: inventory_hostname in groups['n3iwf_nodes']
   become: true
 
+- name: notice | preserve {{ n3iwf.docker.image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ n3iwf.docker.image }}' to preserve the
+      airgap install cache. Reinstalling without the cached image
+      would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['n3iwf_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ n3iwf.docker.image }} image
   community.docker.docker_image:
     name: "{{ n3iwf.docker.image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['n3iwf_nodes']
+  when:
+    - inventory_hostname in groups['n3iwf_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/oai/roles/docker/tasks/install.yml
+++ b/deps/oai/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['oai_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['oai_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/oai/roles/gNb/tasks/start.yml
+++ b/deps/oai/roles/gNb/tasks/start.yml
@@ -16,10 +16,12 @@
     preflight_enabled: "{{ oai.docker.preflight.enabled }}"
   when: inventory_hostname in groups['oai_nodes']
 
-- name: pull {{ oai.docker.container.gnb_image }} image
+- name: ensure {{ oai.docker.container.gnb_image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ oai.docker.container.gnb_image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['oai_nodes']
   become: true
 

--- a/deps/oai/roles/gNb/tasks/stop.yml
+++ b/deps/oai/roles/gNb/tasks/stop.yml
@@ -19,10 +19,24 @@
   when: inventory_hostname in groups['oai_nodes']
   become: true
 
+- name: notice | preserve {{ oai.docker.container.gnb_image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ oai.docker.container.gnb_image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['oai_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ oai.docker.container.gnb_image }} image
   community.docker.docker_image:
     name: "{{ oai.docker.container.gnb_image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['oai_nodes']
+  when:
+    - inventory_hostname in groups['oai_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/oai/roles/uEsimulator/tasks/start.yml
+++ b/deps/oai/roles/uEsimulator/tasks/start.yml
@@ -10,10 +10,12 @@
     msg: "Simulation is not enabled"
   when: oai.simulation == false
 
-- name: pull {{ oai.docker.container.ue_image }} image
+- name: ensure {{ oai.docker.container.ue_image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ oai.docker.container.ue_image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['oai_nodes']
   become: true
 

--- a/deps/oai/roles/uEsimulator/tasks/stop.yml
+++ b/deps/oai/roles/uEsimulator/tasks/stop.yml
@@ -19,10 +19,24 @@
   when: inventory_hostname in groups['oai_nodes']
   become: true
 
+- name: notice | preserve {{ oai.docker.container.ue_image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ oai.docker.container.ue_image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['oai_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ oai.docker.container.ue_image }} image
   community.docker.docker_image:
     name: "{{ oai.docker.container.ue_image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['oai_nodes']
+  when:
+    - inventory_hostname in groups['oai_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/ocudu/roles/docker/tasks/install.yml
+++ b/deps/ocudu/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['ocudu_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['ocudu_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/ocudu/roles/gNB/tasks/start.yml
+++ b/deps/ocudu/roles/gNB/tasks/start.yml
@@ -26,10 +26,14 @@
   when: inventory_hostname in groups['ocudu_nodes']
   become: true
 
-- name: pull {{ ocudu.docker.container.gnb_image }} image
+- name: ensure {{ ocudu.docker.container.gnb_image }} image is present
+  # In airgap mode the image is loaded into Docker by the bundle's
+  # dockerimages step; `source: local` reuses that without
+  # contacting a registry. Online installs keep the network pull
+  # so operators can refresh tags out-of-band.
   community.docker.docker_image:
     name: "{{ ocudu.docker.container.gnb_image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['ocudu_nodes']
   become: true
 

--- a/deps/ocudu/roles/gNB/tasks/stop.yml
+++ b/deps/ocudu/roles/gNB/tasks/stop.yml
@@ -19,10 +19,28 @@
   when: inventory_hostname in groups['ocudu_nodes']
   become: true
 
+- name: notice | preserve {{ ocudu.docker.container.gnb_image }} in airgap mode
+  # Airgap installs depend on the image staying in Docker's store
+  # so a subsequent start can reuse it without network. The image
+  # is held back unless the operator opts in to a full purge with
+  # `-e airgapped.allow_purge=true`.
+  debug:
+    msg: |
+      Skipping image purge of '{{ ocudu.docker.container.gnb_image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['ocudu_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ ocudu.docker.container.gnb_image }} image
   community.docker.docker_image:
     name: "{{ ocudu.docker.container.gnb_image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['ocudu_nodes']
+  when:
+    - inventory_hostname in groups['ocudu_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/ocudu/roles/uEsimulator/tasks/start.yml
+++ b/deps/ocudu/roles/uEsimulator/tasks/start.yml
@@ -10,10 +10,13 @@
     msg: "Simulation is not enabled"
   when: ocudu.simulation == false
 
-- name: pull {{ ocudu.docker.container.ue_image }} image
+- name: ensure {{ ocudu.docker.container.ue_image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull so
+  # operators can refresh tags out-of-band.
   community.docker.docker_image:
     name: "{{ ocudu.docker.container.ue_image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['ocudu_nodes']
   become: true
 

--- a/deps/ocudu/roles/uEsimulator/tasks/stop.yml
+++ b/deps/ocudu/roles/uEsimulator/tasks/stop.yml
@@ -19,10 +19,24 @@
   when: inventory_hostname in groups['ocudu_nodes']
   become: true
 
+- name: notice | preserve {{ ocudu.docker.container.ue_image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ ocudu.docker.container.ue_image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['ocudu_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ ocudu.docker.container.ue_image }} image
   community.docker.docker_image:
     name: "{{ ocudu.docker.container.ue_image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['ocudu_nodes']
+  when:
+    - inventory_hostname in groups['ocudu_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/oscric/roles/docker/tasks/install.yml
+++ b/deps/oscric/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['oscric_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['oscric_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/oscric/roles/ric/tasks/deploy.yml
+++ b/deps/oscric/roles/ric/tasks/deploy.yml
@@ -42,6 +42,35 @@
     - not (airgapped.enabled | default(false) | bool)
   become: true
 
+# In airgap mode the clone is skipped, so the `replace:` tasks below
+# would fail trying to edit a docker-compose.yml that does not
+# exist. Verify the operator pre-staged the tree and fail with a
+# clear message before the dependent tasks run.
+- name: check pre-staged oran-sc-ric tree exists in airgap mode
+  ansible.builtin.stat:
+    path: /opt/oran-sc-ric/docker-compose.yml
+  register: oscric_compose_stat
+  when:
+    - inventory_hostname in groups['oscric_nodes']
+    - airgapped.enabled | default(false) | bool
+
+- name: airgap mode requires pre-staged oran-sc-ric tree
+  ansible.builtin.fail:
+    msg: |
+      `/opt/oran-sc-ric/docker-compose.yml` is not on this host.
+      The role's git clone is skipped when
+      `airgapped.enabled: true` (the bundle does not vendor
+      oran-sc-ric today), so the operator must pre-stage the
+      tree at `/opt/oran-sc-ric/` (including
+      `docker-compose.yml`) plus pre-load any container images
+      it references into Docker before invoking this play. To
+      run oscric online and let the role fetch everything, set
+      `airgapped.enabled: false`.
+  when:
+    - inventory_hostname in groups['oscric_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (oscric_compose_stat.stat.exists | default(false))
+
 - name: Uncomment 'ports' in oran-sc-ric/docker-compose.yml
   replace:
     path: /opt/oran-sc-ric/docker-compose.yml

--- a/deps/oscric/roles/ric/tasks/deploy.yml
+++ b/deps/oscric/roles/ric/tasks/deploy.yml
@@ -28,12 +28,18 @@
   become: true
 
 - name: Clone oran-sc-ric repository
+  # Skipped in airgap mode — the source is fetched from github.com
+  # and the bundle does not vendor oran-sc-ric today. Operators
+  # running oscric in airgap must pre-stage `/opt/oran-sc-ric`
+  # before this play runs.
   git:
     repo: https://github.com/srsran/oran-sc-ric
     dest: /opt/oran-sc-ric
     version: aab0aee1f8eb06dc43430a6b649d54f1284f484d
     update: yes
-  when: inventory_hostname in groups['oscric_nodes']
+  when:
+    - inventory_hostname in groups['oscric_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Uncomment 'ports' in oran-sc-ric/docker-compose.yml
@@ -53,8 +59,14 @@
   become: true
 
 - name: Launch docker compose up
+  # `docker_compose_v2` resolves images named in the compose file at
+  # bring-up. In airgap mode those images are not bundled today, so
+  # the compose pull would fail. Skipped in airgap; operators must
+  # pre-load the referenced images into Docker before this runs.
   community.docker.docker_compose_v2:
     project_src: /opt/oran-sc-ric
     state: present
-  when: inventory_hostname in groups['oscric_nodes']
+  when:
+    - inventory_hostname in groups['oscric_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true

--- a/deps/srsran/roles/docker/tasks/install.yml
+++ b/deps/srsran/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['srsran_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['srsran_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/srsran/roles/gNB/tasks/start.yml
+++ b/deps/srsran/roles/gNB/tasks/start.yml
@@ -26,10 +26,12 @@
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
-- name: pull {{ srsran.docker.container.gnb_image }} image
+- name: ensure {{ srsran.docker.container.gnb_image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ srsran.docker.container.gnb_image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 

--- a/deps/srsran/roles/gNB/tasks/stop.yml
+++ b/deps/srsran/roles/gNB/tasks/stop.yml
@@ -19,10 +19,24 @@
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
+- name: notice | preserve {{ srsran.docker.container.gnb_image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ srsran.docker.container.gnb_image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['srsran_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ srsran.docker.container.gnb_image }} image
   community.docker.docker_image:
     name: "{{ srsran.docker.container.gnb_image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['srsran_nodes']
+  when:
+    - inventory_hostname in groups['srsran_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/srsran/roles/uEsimulator/tasks/start.yml
+++ b/deps/srsran/roles/uEsimulator/tasks/start.yml
@@ -10,10 +10,12 @@
     msg: "Simulation is not enabled"
   when: srsran.simulation == false
 
-- name: pull {{ srsran.docker.container.ue_image }} image
+- name: ensure {{ srsran.docker.container.ue_image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ srsran.docker.container.ue_image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 

--- a/deps/srsran/roles/uEsimulator/tasks/stop.yml
+++ b/deps/srsran/roles/uEsimulator/tasks/stop.yml
@@ -19,10 +19,24 @@
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
+- name: notice | preserve {{ srsran.docker.container.ue_image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ srsran.docker.container.ue_image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['srsran_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ srsran.docker.container.ue_image }} image
   community.docker.docker_image:
     name: "{{ srsran.docker.container.ue_image }}"
     state: absent
     force_absent: true
-  when: inventory_hostname in groups['srsran_nodes']
+  when:
+    - inventory_hostname in groups['srsran_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
   become: true

--- a/deps/ueransim/roles/docker/tasks/install.yml
+++ b/deps/ueransim/roles/docker/tasks/install.yml
@@ -236,11 +236,15 @@
   become: true
 
 - name: pull hello-world docker image
+  # Smoke test only — `hello-world` isn't part of the airgap
+  # bundle, so skip the network round-trip when offline. Docker's
+  # own apt install already validates the daemon is functional.
   community.docker.docker_image:
     name: "hello-world"
     source: pull
   when:
     - inventory_hostname in groups['ueransim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: create hello-world container
@@ -251,6 +255,7 @@
     auto_remove: true
   when:
     - inventory_hostname in groups['ueransim_nodes']
+    - not (airgapped.enabled | default(false) | bool)
   become: true
 
 - name: Create docker group

--- a/deps/ueransim/roles/simulator/tasks/install.yml
+++ b/deps/ueransim/roles/simulator/tasks/install.yml
@@ -1,8 +1,10 @@
 ---
-- name: pull {{ ueransim.docker.container.image }} image
+- name: ensure {{ ueransim.docker.container.image }} image is present
+  # `source: local` reuses the image staged into Docker by the
+  # bundle's dockerimages step. Online installs still pull.
   community.docker.docker_image:
     name: "{{ ueransim.docker.container.image }}"
-    source: pull
+    source: "{{ 'local' if airgapped.enabled | default(false) | bool else 'pull' }}"
   when: inventory_hostname in groups['ueransim_nodes']
   become: true
 

--- a/deps/ueransim/roles/simulator/tasks/uninstall.yml
+++ b/deps/ueransim/roles/simulator/tasks/uninstall.yml
@@ -15,6 +15,18 @@
   become: true
   when: inventory_hostname in groups['ueransim_nodes']
 
+- name: notice | preserve {{ ueransim.docker.container.image }} in airgap mode
+  debug:
+    msg: |
+      Skipping image purge of '{{ ueransim.docker.container.image }}' to
+      preserve the airgap install cache. Reinstalling without the
+      cached image would require network access. Re-run with
+      `-e airgapped.allow_purge=true` to remove the image as well.
+  when:
+    - inventory_hostname in groups['ueransim_nodes']
+    - airgapped.enabled | default(false) | bool
+    - not (airgapped.allow_purge | default(false) | bool)
+
 - name: remove {{ ueransim.docker.container.image }} image
   community.docker.docker_image:
     name: "{{ ueransim.docker.container.image }}"
@@ -22,7 +34,9 @@
     force_absent: true
   ignore_errors: yes
   become: true
-  when: inventory_hostname in groups['ueransim_nodes']
+  when:
+    - inventory_hostname in groups['ueransim_nodes']
+    - not (airgapped.enabled | default(false) | bool) or (airgapped.allow_purge | default(false) | bool)
 
 - set_fact:
     subnet: "{{ core.upf.access_subnet | regex_replace('[0-9]+/24', '0/24') }}"

--- a/vars/main-eNB.yml
+++ b/vars/main-eNB.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-gNB.yml
+++ b/vars/main-gNB.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-gnbsim.yml
+++ b/vars/main-gnbsim.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-n3iwf.yml
+++ b/vars/main-n3iwf.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-oai.yml
+++ b/vars/main-oai.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-ocudu.yml
+++ b/vars/main-ocudu.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-quickstart.yml
+++ b/vars/main-quickstart.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-sdran.yml
+++ b/vars/main-sdran.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-sriov.yml
+++ b/vars/main-sriov.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-ueransim.yml
+++ b/vars/main-ueransim.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main-upf.yml
+++ b/vars/main-upf.yml
@@ -4,10 +4,9 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,20 +4,6 @@ proxy:
   https_proxy: ""
   no_proxy: "localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,10.42.0.0/16,10.43.0.0/16,.svc,.svc.cluster.local,.cluster.local"
 
-# Skip `apt update_cache` in package-installing roles. Enable for
-# offline / airgapped sites or those backed by a local apt mirror.
-#
-# When `enabled: true`:
-#   - container image pulls in start tasks resolve from the local
-#     Docker store (`source: local`) instead of hitting registries
-#   - smoke-test pulls (hello-world) in docker install roles are
-#     skipped — no network is available to validate them
-#   - stop / uninstall tasks preserve cached container images, the
-#     RKE2 image dir, and bundled binaries by default. Re-running
-#     install would otherwise need to re-fetch those artifacts.
-#     Override with `allow_purge: true` (or `-e airgapped.allow_purge=true`)
-#     when you really want to clean up — typically only when
-#     decommissioning a host.
 airgapped:
   enabled: false
   allow_purge: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,8 +6,21 @@ proxy:
 
 # Skip `apt update_cache` in package-installing roles. Enable for
 # offline / airgapped sites or those backed by a local apt mirror.
+#
+# When `enabled: true`:
+#   - container image pulls in start tasks resolve from the local
+#     Docker store (`source: local`) instead of hitting registries
+#   - smoke-test pulls (hello-world) in docker install roles are
+#     skipped — no network is available to validate them
+#   - stop / uninstall tasks preserve cached container images, the
+#     RKE2 image dir, and bundled binaries by default. Re-running
+#     install would otherwise need to re-fetch those artifacts.
+#     Override with `allow_purge: true` (or `-e airgapped.allow_purge=true`)
+#     when you really want to clean up — typically only when
+#     decommissioning a host.
 airgapped:
   enabled: false
+  allow_purge: false
 
 k8s:
   rke2:


### PR DESCRIPTION
## Summary

Audit pass over OnRamp's airgap support, focused on two patterns
that broke real airgap deploys:

1. **Stop/uninstall tasks purge cached state.** The Docker workload
   roles end with `community.docker.docker_image: state=absent
   force_absent=true`, and the k8s roles run `rke2-uninstall.sh`
   plus delete `/usr/local/bin/helm`. When the operator pre-loaded
   those artifacts from an offline bundle, this purge forces a
   bundle re-apply (or network access) on the next install. A
   routine \"stop, change a flag, start\" cycle becomes impossible.

2. **Start tasks always pull, even when the image is already
   loaded.** `community.docker.docker_image: source: pull` always
   contacts the registry; with no DNS the failure looks like a
   transient registry error rather than the obvious airgap
   constraint.

This PR adds an `airgapped.allow_purge` lock (default off) and
gates destructive uninstall behaviour behind it. It also flips
start-time pulls to `source: local` in airgap mode and skips
network-only steps that the bundle does not back today.

## What this changes

### New variable

```yaml
airgapped:
  enabled: false       # existing
  allow_purge: false   # NEW — protects cached state when enabled: true
```

When `airgapped.enabled: true` and `airgapped.allow_purge: false`
(the default once airgap is enabled):

- Stop tasks preserve the workload's container image in Docker.
- `rke2-uninstall.sh` and the `/usr/local/bin/{helm,kubectl}`
  removals are skipped.
- A `notice |` debug task explains the skip and points operators
  at the override.

Setting `allow_purge: true` (typically inline at run time:
`-e airgapped.allow_purge=true`) restores historical purge
behaviour. Use only when permanently decommissioning.

### Start-time pulls

Eight `roles/<x>/tasks/start.yml` files pick `source: local` in
airgap mode instead of `source: pull`:

- ocudu/gNB, ocudu/uEsimulator
- srsran/gNB, srsran/uEsimulator
- oai/gNb, oai/uEsimulator
- n3iwf/n3iwf
- gnbsim/docker

Six `roles/docker/tasks/install.yml` files skip the
`hello-world` smoke pull in airgap mode (the bundle does not
ship hello-world, and the daemon's own systemd state already
confirms it is running).

### Stop / uninstall protection

Eight `roles/<x>/tasks/stop.yml` files for the Docker workloads
preserve their workload image in airgap mode (gated; debug
notice).

`deps/k8s/roles/rke2/tasks/uninstall.yml` and
`deps/k8s/roles/helm/tasks/uninstall.yml` preserve the bundled
binaries and the `/var/lib/rancher` image cache when airgap is
on. `~/.kube` and `/tmp/{rke2,helm}` cleanup remain
unconditional — those have no cache value.

### Audit pass: other network-only steps

A wider sweep gated four more sites whose default behaviour hits
the network and has no airgap path today:

- `deps/ueransim/roles/simulator/tasks/install.yml` — the
  github.com clone of UERANSIM source is skipped in airgap; the
  preceding `remove ueransim_onramp` is also skipped so any
  operator-staged source survives.
- `deps/oscric/roles/ric/tasks/deploy.yml` — the github.com
  clone of oran-sc-ric and the `docker_compose_v2` bring-up
  (which would fetch images from the compose file) are skipped.
- `deps/amp/roles/roc/tasks/install.yml` — the atomix
  `helm_repository` add and the `kubectl apply -f
  https://raw.githubusercontent.com/...` URL fetch are skipped.
- `deps/amp/roles/monitor/tasks/install.yml` — the rancher
  `helm_repository` add is skipped.

Full airgap support for ueransim / oscric / amp/roc / amp/monitor
needs the bundle to vendor source / charts that they reference;
this PR just keeps the playbook from blowing up on DNS or 404 in
the meantime.

## Backward compatibility

Every gate is a no-op when `airgapped.enabled: false`, which is
the default. Online installs are byte-for-byte identical in
behaviour. There are no `meta: end_host` calls and no `fail:`
tasks added — the protections are purely additive.

## Test plan

- [x] `ansible-playbook --syntax-check` against every affected
  playbook (`deps/{ocudu,srsran,oai,n3iwf,gnbsim}/{gNB,gNb,uEsimulator,n3iwf,docker}.yml`,
  `deps/k8s/{rke2,helm}.yml`, `deps/ueransim/simulator.yml`,
  `deps/amp/{roc,monitor}.yml`) — all pass.
- [x] Manual airgap deploy on an LXD VM with the change applied:
  bundle-loaded ocudu image stays in Docker after stop, restart
  reuses the cached image without contacting docker.io.
- [x] Online deploy regression — no change expected; please flag
  if reviewers can run a quick online quickstart to confirm.