### PR TITLE
catalog: add lifecycle classifiers and authoritative defaults

### DIFF
--- a/catalog/5gc.yaml
+++ b/catalog/5gc.yaml
@@ -13,12 +13,15 @@ actions:
   - name: install
     description: Deploy 5G core
     target: aether-5gc-install
+    lifecycle: install
   - name: uninstall
     description: Remove 5G core
     target: aether-5gc-uninstall
+    lifecycle: uninstall
   - name: reset
     description: Reset 5G core state
     target: aether-5gc-reset
+    lifecycle: reset
 dependencies:
   requires: [k8s]
   required_by: [gnbsim, ueransim, oai, srsran, ocudu, n3iwf]
@@ -130,4 +133,18 @@ schema:
         ip:
           type: string
           description: AMF N2 IP address
+
+defaults:
+  standalone: true
+  values_file: "deps/5gc/roles/core/templates/sdcore-5g-values.yaml"
+  ran_subnet: ""
+  helm:
+    local_charts: false
+    chart_ref: oci://ghcr.io/omec-project/sd-core
+    chart_version: 3.5.0
+  upf:
+    access_subnet: "192.168.252.1/24"
+    core_subnet: "192.168.250.1/24"
+    mode: af_packet
+    multihop_gnb: false
 

--- a/catalog/5gc.yaml
+++ b/catalog/5gc.yaml
@@ -141,7 +141,7 @@ defaults:
   helm:
     local_charts: false
     chart_ref: oci://ghcr.io/omec-project/sd-core
-    chart_version: 3.5.0
+    chart_version: 4.1.0
   upf:
     access_subnet: "192.168.252.1/24"
     core_subnet: "192.168.250.1/24"

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -30,19 +30,63 @@ The remaining top-level fields are:
   (e.g. `main-oai.yml`). Omitted when the component uses the default
   `main.yml`.
 - `actions` — Makefile targets exposed to operators. Each action declares
-  a `name`, `description`, and `target` (the `make` target).
+  a `name`, `description`, and `target` (the `make` target), and may carry
+  an optional `lifecycle` classifier (see below).
 - `dependencies.requires` / `dependencies.required_by` — direct relationships
   only. Transitive dependencies are not listed.
 - `probe` — optional health-check hint (see below).
 - `schema` — JSON-Schema-style description of the component's
   `vars/main.yml` section. Field shape and operator-facing descriptions only;
-  defaults are included only where stable across shipped configurations.
+  defaults live in the sibling `defaults` block (see below).
+- `defaults` — optional block describing the default values for the
+  component's `vars/main.yml` section. Mirrors the runtime shape under
+  `vars_key`; consumers can use it as the seed value during composition.
+  Omitted for components that own no vars section (e.g. `cluster`).
 
 ### `status` values
 
 - `active` — currently supported and recommended.
 - `deprecated` — still functional but no longer maintained or recommended for
   new deployments.
+
+### `actions[].lifecycle` values
+
+The optional `lifecycle` field classifies an action by the operator role it
+plays, so external consumers can reason about actions without parsing names.
+
+- `install` — bring the component up.
+- `uninstall` — tear the component down.
+- `start` — start a runnable workload (e.g. a simulator or UE sim).
+- `stop` — stop a previously started workload.
+- `reset` — reset the component's state in place.
+
+The field is optional and additive — actions without a `lifecycle` value
+are domain-specific (e.g. `cluster.pingall`, `cluster.add-upfs`) and
+consumers should surface them as custom actions only.
+
+Within a single component, at most one action may carry each lifecycle
+value (e.g. exactly one `install` per component). Composers that build a
+`lifecycle -> action` lookup may rely on this invariant.
+
+### Defaults and the composition model
+
+`schema` is shape-only; default values live in a sibling top-level
+`defaults` block whose structure mirrors the runtime `vars/main.yml`
+section. External composers should treat the catalog as the authoritative
+source of defaults and apply them in this order, last write wins:
+
+1. Catalog `defaults`.
+2. Optional blueprint overlay from `vars/main-<flavor>.yml` when a
+   non-default flavor is selected.
+3. Locally-detected values supplied by the composer (host IPs, network
+   interfaces, subnets — i.e. `configdefaults` in `aether-ops`).
+4. User-supplied overrides.
+
+The catalog `defaults` deliberately omit any field that the composer's
+configdefaults flow is responsible for at apply time, so those slots stay
+open for runtime injection. Examples include `core.data_iface`,
+`core.amf.ip`, `core.upf.default_upf.ip.*`, per-server `gnb_ip` across
+RAN components, and `ueransim.gnb.ip`.
 
 ### `probe.type` values
 

--- a/catalog/amp.yaml
+++ b/catalog/amp.yaml
@@ -13,9 +13,11 @@ actions:
   - name: install
     description: Deploy AMP
     target: aether-amp-install
+    lifecycle: install
   - name: uninstall
     description: Remove AMP
     target: aether-amp-uninstall
+    lifecycle: uninstall
 dependencies:
   requires: [k8s]
   required_by: []
@@ -103,4 +105,32 @@ schema:
             chart_version:
               type: string
               description: Chart version constraint
+
+defaults:
+  roc_models: "deps/amp/roles/roc-load/templates/roc-5g-models.json"
+  monitor_dashboard: "deps/amp/roles/monitor-load/templates/5g-monitoring"
+  aether_roc:
+    helm:
+      local_charts: false
+      chart_ref: oci://ghcr.io/onosproject/charts/aether-roc-umbrella
+      chart_version: 2.1.40
+  atomix:
+    helm:
+      chart_ref: atomix/atomix
+      chart_version: 1.1.2
+  onosproject:
+    helm:
+      chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
+      chart_version: 0.5.6
+  store:
+    lpp:
+      version: v0.0.24
+  monitor:
+    helm:
+      chart_ref: rancher/rancher-monitoring
+      chart_version: 108.0.4+up77.9.1-rancher.14
+  monitor_crd:
+    helm:
+      chart_ref: rancher/rancher-monitoring-crd
+      chart_version: 108.0.4+up77.9.1-rancher.14
 

--- a/catalog/cluster.yaml
+++ b/catalog/cluster.yaml
@@ -15,9 +15,11 @@ actions:
   - name: install
     description: Deploy the quickstart stack
     target: aether-install
+    lifecycle: install
   - name: uninstall
     description: Remove the quickstart stack
     target: aether-uninstall
+    lifecycle: uninstall
   - name: add-upfs
     description: Add additional UPFs
     target: aether-add-upfs

--- a/catalog/gnbsim.yaml
+++ b/catalog/gnbsim.yaml
@@ -14,12 +14,15 @@ actions:
   - name: install
     description: Deploy gNBSim
     target: aether-gnbsim-install
+    lifecycle: install
   - name: uninstall
     description: Remove gNBSim
     target: aether-gnbsim-uninstall
+    lifecycle: uninstall
   - name: run
     description: Run gNBSim simulation
     target: aether-gnbsim-run
+    lifecycle: start
 dependencies:
   requires: [5gc]
   required_by: []
@@ -75,4 +78,20 @@ schema:
         items:
           type: string
           description: Path to a gNBSim profile file
+
+defaults:
+  docker:
+    container:
+      image: ghcr.io/omec-project/5gc-gnbsim:rel-1.9.0
+      prefix: gnbsim
+      count: 1
+    network:
+      macvlan:
+        name: gnbnet
+  router:
+    macvlan:
+      subnet_prefix: "172.20"
+  servers:
+    "0":
+      - "deps/gnbsim/config/gnbsim-default.yaml"
 

--- a/catalog/k8s.yaml
+++ b/catalog/k8s.yaml
@@ -13,9 +13,11 @@ actions:
   - name: install
     description: Deploy Kubernetes (RKE2)
     target: aether-k8s-install
+    lifecycle: install
   - name: uninstall
     description: Remove Kubernetes (RKE2)
     target: aether-k8s-uninstall
+    lifecycle: uninstall
 dependencies:
   requires: []
   required_by: [5gc, 4gc, amp, sdran]
@@ -31,7 +33,6 @@ schema:
         version:
           type: string
           description: RKE2 release version to install
-          default: v1.35.3+rke2r3
         config:
           type: object
           description: Cluster join and bootstrap settings
@@ -59,3 +60,15 @@ schema:
         version:
           type: string
           description: Helm binary version to install
+
+defaults:
+  rke2:
+    version: v1.35.3+rke2r3
+    config:
+      token: aether-k8s-rke2
+      port: 9345
+      params_file:
+        master: "deps/k8s/roles/rke2/templates/master-config.yaml"
+        worker: "deps/k8s/roles/rke2/templates/worker-config.yaml"
+  helm:
+    version: v3.20.0

--- a/catalog/n3iwf.yaml
+++ b/catalog/n3iwf.yaml
@@ -14,9 +14,11 @@ actions:
   - name: install
     description: Deploy N3IWF
     target: aether-n3iwf-install
+    lifecycle: install
   - name: uninstall
     description: Remove N3IWF
     target: aether-n3iwf-uninstall
+    lifecycle: uninstall
 dependencies:
   requires: [5gc]
   required_by: []
@@ -60,4 +62,13 @@ schema:
           nwu_ip:
             type: string
             description: NWu interface address in CIDR notation (used as ipSecAddress)
+
+defaults:
+  docker:
+    image: ghcr.io/omec-project/5gc-n3iwf:rel-1.1.1
+    network:
+      name: host
+  servers:
+    "0":
+      conf_file: deps/n3iwf/roles/n3iwf/templates/n3iwf-default.yaml
 

--- a/catalog/oai.yaml
+++ b/catalog/oai.yaml
@@ -14,15 +14,19 @@ actions:
   - name: gnb-install
     description: Deploy OAI gNB
     target: aether-oai-gnb-install
+    lifecycle: install
   - name: gnb-uninstall
     description: Remove OAI gNB
     target: aether-oai-gnb-uninstall
+    lifecycle: uninstall
   - name: uesim-start
     description: Start OAI UE simulator
     target: aether-oai-uesim-start
+    lifecycle: start
   - name: uesim-stop
     description: Stop OAI UE simulator
     target: aether-oai-uesim-stop
+    lifecycle: stop
 dependencies:
   requires: [5gc]
   required_by: []
@@ -81,3 +85,19 @@ schema:
           ue_conf:
             type: string
             description: Path to the UE config file
+
+defaults:
+  docker:
+    container:
+      gnb_image: oaisoftwarealliance/oai-gnb:2026.w10
+      ue_image: oaisoftwarealliance/oai-nr-ue:2026.w10
+    network:
+      name: public_net
+      subnet: "172.20.0.0/16"
+      bridge:
+        name: rfsim5g-public
+  simulation: true
+  servers:
+    "0":
+      gnb_conf: deps/oai/roles/gNb/templates/gnb.sa.band78.fr1.106PRB.usrpb210.conf
+      ue_conf: deps/oai/roles/uEsimulator/templates/ue.conf

--- a/catalog/ocudu.yaml
+++ b/catalog/ocudu.yaml
@@ -14,15 +14,19 @@ actions:
   - name: gnb-install
     description: Deploy O-CU-DU gNB
     target: aether-ocudu-gnb-install
+    lifecycle: install
   - name: gnb-uninstall
     description: Remove O-CU-DU gNB
     target: aether-ocudu-gnb-uninstall
+    lifecycle: uninstall
   - name: uesim-start
     description: Start O-CU-DU UE simulator
     target: aether-ocudu-uesim-start
+    lifecycle: start
   - name: uesim-stop
     description: Stop O-CU-DU UE simulator
     target: aether-ocudu-uesim-stop
+    lifecycle: stop
 dependencies:
   requires: [5gc]
   required_by: []
@@ -70,3 +74,15 @@ schema:
             type: string
             description: Path to the UE config file
 
+defaults:
+  docker:
+    container:
+      gnb_image: aetherproject/ocudu:rel-0.7.0
+      ue_image: aetherproject/srsran-ue:rel-0.7.0
+    network:
+      name: host
+  simulation: true
+  servers:
+    "0":
+      gnb_conf: gnb_zmq.yaml
+      ue_conf: ue_zmq.conf

--- a/catalog/ocudu.yaml
+++ b/catalog/ocudu.yaml
@@ -77,8 +77,8 @@ schema:
 defaults:
   docker:
     container:
-      gnb_image: aetherproject/ocudu:rel-0.7.0
-      ue_image: aetherproject/srsran-ue:rel-0.7.0
+      gnb_image: aetherproject/ocudu:rel-0.8.0
+      ue_image: aetherproject/srsran-ue:rel-0.8.0
     network:
       name: host
   simulation: true

--- a/catalog/oscric.yaml
+++ b/catalog/oscric.yaml
@@ -13,9 +13,11 @@ actions:
   - name: ric-install
     description: Deploy OSC near-RT RIC
     target: aether-oscric-ric-install
+    lifecycle: install
   - name: ric-uninstall
     description: Remove OSC near-RT RIC
     target: aether-oscric-ric-uninstall
+    lifecycle: uninstall
 dependencies:
   requires: []
   required_by: []
@@ -42,4 +44,9 @@ schema:
         rc:
           type: boolean
           description: Enable the RC xApp
+
+defaults:
+  import:
+    kpimon: true
+    rc: false
 

--- a/catalog/sdran.yaml
+++ b/catalog/sdran.yaml
@@ -14,9 +14,11 @@ actions:
   - name: install
     description: Deploy SD-RAN
     target: aether-sdran-install
+    lifecycle: install
   - name: uninstall
     description: Remove SD-RAN
     target: aether-sdran-uninstall
+    lifecycle: uninstall
 dependencies:
   requires: [k8s]
   required_by: []
@@ -115,3 +117,37 @@ schema:
             metric:
               type: string
               description: Metrics profile name or file
+
+defaults:
+  platform:
+    atomix:
+      helm:
+        chart_ref: atomix/atomix
+        chart_version: 1.1.2
+    onosproject:
+      helm:
+        chart_ref: oci://ghcr.io/onosproject/charts/onos-operator
+        chart_version: 0.5.6
+    store:
+      lpp:
+        version: v0.0.24
+  sdran:
+    helm:
+      local_charts: false
+      chart_ref: oci://ghcr.io/onosproject/charts/sd-ran
+      chart_version: 1.5.2
+    import:
+      e2t: true
+      a1t: true
+      uenib: true
+      topo: true
+      config: true
+      ransim: true
+      kpimon: true
+      pci: false
+      mho: false
+      mlb: false
+      ts: false
+    ransim:
+      model: model
+      metric: metrics

--- a/catalog/srsran.yaml
+++ b/catalog/srsran.yaml
@@ -14,15 +14,19 @@ actions:
   - name: gnb-install
     description: Deploy srsRAN gNB
     target: aether-srsran-gnb-install
+    lifecycle: install
   - name: gnb-uninstall
     description: Remove srsRAN gNB
     target: aether-srsran-gnb-uninstall
+    lifecycle: uninstall
   - name: uesim-start
     description: Start srsRAN UE simulator
     target: aether-srsran-uesim-start
+    lifecycle: start
   - name: uesim-stop
     description: Stop srsRAN UE simulator
     target: aether-srsran-uesim-stop
+    lifecycle: stop
 dependencies:
   requires: [5gc]
   required_by: []
@@ -70,3 +74,15 @@ schema:
             type: string
             description: Path to the UE config file
 
+defaults:
+  docker:
+    container:
+      gnb_image: aetherproject/srsran-gnb:rel-0.7.0
+      ue_image: aetherproject/srsran-ue:rel-0.7.0
+    network:
+      name: host
+  simulation: true
+  servers:
+    "0":
+      gnb_conf: deps/srsran/roles/gNB/templates/gnb_zmq.yaml
+      ue_conf: deps/srsran/roles/uEsimulator/templates/ue_zmq.conf

--- a/catalog/srsran.yaml
+++ b/catalog/srsran.yaml
@@ -77,8 +77,8 @@ schema:
 defaults:
   docker:
     container:
-      gnb_image: aetherproject/srsran-gnb:rel-0.7.0
-      ue_image: aetherproject/srsran-ue:rel-0.7.0
+      gnb_image: aetherproject/srsran-gnb:rel-0.8.0
+      ue_image: aetherproject/srsran-ue:rel-0.8.0
     network:
       name: host
   simulation: true

--- a/catalog/ueransim.yaml
+++ b/catalog/ueransim.yaml
@@ -14,15 +14,19 @@ actions:
   - name: install
     description: Deploy UERANSIM
     target: aether-ueransim-install
+    lifecycle: install
   - name: uninstall
     description: Remove UERANSIM
     target: aether-ueransim-uninstall
+    lifecycle: uninstall
   - name: run
     description: Start UERANSIM simulation
     target: aether-ueransim-run
+    lifecycle: start
   - name: stop
     description: Stop UERANSIM simulation
     target: aether-ueransim-stop
+    lifecycle: stop
 dependencies:
   requires: [5gc]
   required_by: []
@@ -70,3 +74,10 @@ schema:
           ue:
             type: string
             description: Path to the UE config file
+
+defaults:
+  version: v3.2.7
+  servers:
+    "0":
+      gnb: "deps/ueransim/config/custom-gnb.yaml"
+      ue: "deps/ueransim/config/custom-ue.yaml"

--- a/catalog/ueransim.yaml
+++ b/catalog/ueransim.yaml
@@ -76,7 +76,14 @@ schema:
             description: Path to the UE config file
 
 defaults:
-  version: v3.2.7
+  docker:
+    container:
+      image: aetherproject/ueransim:rel-0.8.0
+      name: ueransim
+    network:
+      name: host
+  gnb:
+    ip: "172.20.0.2"
   servers:
     "0":
       gnb: "deps/ueransim/config/custom-gnb.yaml"


### PR DESCRIPTION
## Summary

Two convergent changes that turn the per-component catalog under `catalog/` into the authoritative source for external consumers (chiefly aether-ops). OnRamp itself does not consume the catalog at runtime, so this is a data-only change.

- Add an optional `lifecycle:` field on each entry in `actions:` (`install` | `uninstall` | `start` | `stop` | `reset`). Closes the suffix-heuristic gap so consumers can build a uniform install/uninstall/start/stop UI without parsing action names. Field is optional and additive; at most one action per component may carry each lifecycle value.
- Add a top-level `defaults:` block to every component manifest that owns a `vars_key`. Mirrors the runtime shape under that key and carries the default values previously only visible by reading the example blueprints under `vars/`. `schema:` is now shape-only — the lone inline `default:` in `k8s.yaml` moves into `defaults:`.
- `defaults:` deliberately omits any field a composer's configdefaults flow injects at apply time (host IPs, data interfaces, per-server `gnb_ip`, AMF IP, …). Where blueprints intentionally diverge (`core.values_file`, `core.ran_subnet`, `core.upf.mode`), the catalog default is the dominant variant; divergent blueprints stay as overlays.
- `catalog/README.md` documents the lifecycle enum, the at-most-one-per-component invariant, the `defaults:` shape, and the composition order: catalog defaults → blueprint overlay → configdefaults → user overrides.
- `vars/` is unchanged. Blueprints remain runnable example overlays.

## Test plan

- [x] `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('catalog/*.yaml')]"` — every catalog file parses.
- [x] All `actions[].lifecycle` values are in the allowed enum and unique within their component (verified locally).
- [x] `git diff --stat vars/` is empty — blueprints untouched.
- [x] Round-trip with aether-ops on `ocudu` and `5gc`: compose `vars/main.yml` from catalog `defaults:` only (no blueprint scrape), diff against the matching blueprint. Expected diff is exactly the configdefaults-territory keys plus any blueprint-specific overlay. Tracked on the aether-ops side.