### PR TITLE
Fix: UERANSIM CI job failure on Ubuntu 22.04

### DIFF
--- a/.github/workflows/reusable-quickstart.yml
+++ b/.github/workflows/reusable-quickstart.yml
@@ -81,10 +81,7 @@ jobs:
         run: |
           if command -v ansible-playbook >/dev/null 2>&1; then
             echo "Ansible is already installed"
-            exit 0
-          fi
-
-          if [ "${{ runner.os }}" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then
+          elif [ "${{ runner.os }}" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then
             if command -v sudo >/dev/null 2>&1; then
               sudo apt-get update
               sudo apt-get install -y ansible
@@ -97,6 +94,9 @@ jobs:
             echo "Use an Ubuntu/Debian runner or preinstall Ansible on the selected runner." >&2
             exit 1
           fi
+
+          ansible-galaxy collection install -r requirements.yml
+          ansible-galaxy collection list community.docker
 
       - name: Configure OnRamp
         run: |

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: community.docker
+    version: 5.2.0


### PR DESCRIPTION
This PR pins the version of community.docker from Ansible Galaxy so that the Aether OnRamp UERANSIM action passes.

Validated here: https://github.com/andybavier/aether-onramp/actions/runs/25528816628