### PR TITLE
ocudu/gNB: bind-mount /dev/bus/usb for USRP hot-plug visibility

### DIFF
--- a/deps/ocudu/roles/gNB/tasks/start.yml
+++ b/deps/ocudu/roles/gNB/tasks/start.yml
@@ -65,6 +65,7 @@
     volumes:
       - /tmp/gnb_config.yaml:/opt/gnb_config.yaml
       - /dev/hugepages:/dev/hugepages
+      - /dev/bus/usb:/dev/bus/usb
     devices:
       - /dev/vfio:/dev/vfio
     privileged: true


### PR DESCRIPTION
## Summary

OCUDU gNB containers can hit "USB open failed: insufficient
permissions" during USRP B210 startup. The privileged container's
`/dev` is a private tmpfs populated only at container start, so any
new minor the kernel allocates after a firmware-load re-enumeration
is not visible inside the container.

Bind-mounting `/dev/bus/usb` exposes the host devtmpfs to the
container so re-enumerated devices show up live. `--privileged`
already covers the cgroup device permissions, so this change is
purely about visibility and is a no-op for setups that don't hit
the re-enumeration path.

The full root-cause analysis is in the commit message.

## Why this is rare

The failure depends on whether the kernel reuses the original
devnum when the USRP re-attaches. With reuse, UHD's retry loop
eventually completes; without it, the gNB may not see the radio.
Only observed on a small subset of B210 hardware so far.

## Test plan

- [x] Reproduced on a B210 host with `aetherproject/ocudu:rel-0.7.0`:
      27 `USB open failed` errors before the change, 0 after.
- [x] Re-deployed end-to-end via `make aether-ocudu-gnb-uninstall`
      then `make aether-ocudu-gnb-install`; confirmed
      `/proc/self/mountinfo` inside the container reports
      `/dev/bus/usb` as `devtmpfs` (host `udev` fs) rather than a
      tmpfs entry.
- [x] No regression on hosts that never hit the re-enumeration path
      (mount is purely additive).