### PR TITLE
Restore srsRAN simulated UE connectivity

### DIFF
--- a/.github/workflows/quickstart-srsran.yml
+++ b/.github/workflows/quickstart-srsran.yml
@@ -42,7 +42,6 @@ jobs:
         docker ps
       run_commands: |
         make aether-srsran-uesim-start
-      run_continue_on_error: true
       validate_commands: |
         docker exec rfsim5g-srsran-nr-ue ip netns exec ue1 ping -c 5 192.168.250.1 > srs-uesim.log
         grep "0% packet loss" srs-uesim.log
@@ -51,5 +50,6 @@ jobs:
       extra_log_commands: |
         docker logs srsran-gnb > logs/srsran_gnb.log 2>&1 || echo "Failed to get srsran-gnb logs"
         docker logs rfsim5g-srsran-nr-ue > logs/srsran_ue.log 2>&1 || echo "Failed to get srsran-nr-ue logs"
+        docker exec rfsim5g-srsran-nr-ue cat /tmp/ue.log > logs/srsran_ue_internal.log 2>&1 || echo "Failed to get internal srsRAN UE logs"
       cleanup_targets: aether-srsran-uesim-stop aether-srsran-gnb-uninstall aether-5gc-uninstall aether-k8s-uninstall
     secrets: inherit

--- a/deps/srsran/roles/uEsimulator/tasks/start.yml
+++ b/deps/srsran/roles/uEsimulator/tasks/start.yml
@@ -55,14 +55,23 @@
   when: inventory_hostname in groups['srsran_nodes']
   become: true
 
-- pause:
-    seconds: 10
+- name: wait for UE tunnel interface
+  community.docker.docker_container_exec:
+    container: rfsim5g-srsran-nr-ue
+    command: "ip netns exec ue1 ip link show tun_srsue"
+  register: ue_tunnel
+  until: ue_tunnel.rc == 0
+  retries: 18
+  delay: 5
+  changed_when: false
+  when: inventory_hostname in groups['srsran_nodes']
+  become: true
 
 - name: add default route for UE
   community.docker.docker_container_exec:
     container: rfsim5g-srsran-nr-ue
     command: >-
-      ip netns exec ue1 ip route add default via
+      ip netns exec ue1 ip route replace default via
       {{ (core.upf.default_upf.ue_ip_pool.split('.'))[:3] | join('.') }}.{{ (core.upf.default_upf.ue_ip_pool.split('.')[3] | int) + 1 }}
       dev tun_srsue
   when: inventory_hostname in groups['srsran_nodes']

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -46,7 +46,7 @@ core:
 srsran:
   docker:
     container:
-      # rel-0.7.0 does not establish the simulated ZMQ UE link in CI.
+      # rel-0.7.0 does not establish the simulated ZMQ UE link.
       gnb_image: aetherproject/srsran-gnb:rel-0.4.0
       ue_image: aetherproject/srsran-ue:rel-0.4.0
     network:

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -46,8 +46,9 @@ core:
 srsran:
   docker:
     container:
-      gnb_image: aetherproject/srsran-gnb:rel-0.7.0
-      ue_image: aetherproject/srsran-ue:rel-0.7.0
+      # rel-0.7.0 does not establish the simulated ZMQ UE link in CI.
+      gnb_image: aetherproject/srsran-gnb:rel-0.4.0
+      ue_image: aetherproject/srsran-ue:rel-0.4.0
     network:
       name: host
   simulation: true


### PR DESCRIPTION
## Summary

- pin the srsRAN gNB and UE images to the last-known-compatible `rel-0.4.0` release
- wait for the UE tunnel interface instead of relying on a fixed sleep
- fail immediately when UE startup fails and archive the internal UE log

## Root cause

The srsRAN workflow last succeeded with the `rel-0.4.0` image pair. After the blueprint moved to `rel-0.7.0`, the gNB and UE containers started but the simulated ZMQ UE link never established, so `tun_srsue` was never created. The srsRAN launch tasks and ZMQ configuration were unchanged across that image update.

## Test results

- failing `rel-0.7.0` run: https://github.com/andybavier/aether-onramp/actions/runs/27037171597
- passing `rel-0.4.0` run: https://github.com/andybavier/aether-onramp/actions/runs/27037970727

The readiness polling and added UE log collection should make future startup failures deterministic and diagnosable.