### PR TITLE
Bump srsRAN and OCUDU images to rel-0.8.2

### DIFF
--- a/vars/main-ocudu.yml
+++ b/vars/main-ocudu.yml
@@ -46,8 +46,8 @@ core:
 ocudu:
   docker:
     container:
-      gnb_image: aetherproject/ocudu:rel-0.7.0
-      ue_image: aetherproject/srsran-ue:rel-0.7.0
+      gnb_image: aetherproject/ocudu:rel-0.8.2
+      ue_image: aetherproject/srsran-ue:rel-0.8.2
     network:
       name: host
   simulation: true

--- a/vars/main-srsran.yml
+++ b/vars/main-srsran.yml
@@ -46,9 +46,8 @@ core:
 srsran:
   docker:
     container:
-      # rel-0.7.0 does not establish the simulated ZMQ UE link.
-      gnb_image: aetherproject/srsran-gnb:rel-0.4.0
-      ue_image: aetherproject/srsran-ue:rel-0.4.0
+      gnb_image: aetherproject/srsran-gnb:rel-0.8.2
+      ue_image: aetherproject/srsran-ue:rel-0.8.2
     network:
       name: host
   simulation: true


### PR DESCRIPTION
## Summary
- update the srsRAN quickstart to use aetherproject/srsran-gnb:rel-0.8.2 and aetherproject/srsran-ue:rel-0.8.2
- update the OCUDU quickstart to use aetherproject/ocudu:rel-0.8.2 and aetherproject/srsran-ue:rel-0.8.2

## Validation
- verified the portable rel-0.8.2 image set passes the aether-onramp srsRAN and OCUDU workflows on GitHub-hosted runners
