### PR TITLE
Make the DPDK reboot timeout configurable

### DIFF
--- a/deps/ocudu/roles/dpdk/defaults/main.yml
+++ b/deps/ocudu/roles/dpdk/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Seconds Ansible waits for the host to come back after the early DPDK reboot
+# (realtime kernel + boot-time isolcpus/hugepage settings). The role defaults
+# to 300s. Hosts with large 1 GB hugepage reservations or a slow PREEMPT_RT
+# first boot can take longer and time out even though the reboot itself
+# succeeded; raise this for them via group_vars, host_vars, or -e.
+dpdk_reboot_timeout: 300

--- a/deps/ocudu/roles/dpdk/tasks/main.yml
+++ b/deps/ocudu/roles/dpdk/tasks/main.yml
@@ -88,7 +88,7 @@
 
 - name: reboot early to apply realtime kernel and boot-time DPDK settings
   ansible.builtin.reboot:
-    reboot_timeout: 300
+    reboot_timeout: "{{ dpdk_reboot_timeout | default(300) }}"
   become: true
   when: (rt_kernel_installed is defined and rt_kernel_installed is changed) or grub_cmdline_result.changed
 


### PR DESCRIPTION
## Summary

The early reboot in the `dpdk` role (`deps/ocudu/roles/dpdk/tasks/main.yml`) — the one that applies the realtime kernel and boot-time DPDK settings — hardcodes `reboot_timeout: 300`:

```yaml
- name: reboot early to apply realtime kernel and boot-time DPDK settings
  ansible.builtin.reboot:
    reboot_timeout: 300
```

On hosts with large 1 GB hugepage reservations or a slow PREEMPT_RT first boot, the box can take longer than 300 s to come back. When that happens the task fails (`Timed out waiting for last boot time check`) **even though the reboot itself succeeded** — the play aborts and the following `gnb-install` is skipped. Observed on a 96-core / ~1.5 TB host where first boot after isolating cores + allocating hugepages ran ~310 s.

## Change

- Read the timeout from a `dpdk_reboot_timeout` variable, defaulting to the existing `300` (`reboot_timeout: "{{ dpdk_reboot_timeout | default(300) }}"`), so behavior is unchanged unless the operator overrides it.
- Document the knob in new `roles/dpdk/defaults/main.yml` so it is discoverable in the conventional location. Slow-booting hosts can raise it via group_vars/host_vars/`-e` without editing the role.

No functional change at the default; single reboot site in the role.

## Test

- YAML parses; default preserves the current 300 s.
- Verified against the failing case: the reboot succeeds and only the watch times out, so a higher `dpdk_reboot_timeout` lets the play continue on slow-booting hosts.